### PR TITLE
dev: added workgroup-based ordering enforcement

### DIFF
--- a/dev/calltype_common_definitions.tmpl
+++ b/dev/calltype_common_definitions.tmpl
@@ -2,7 +2,8 @@
 {{/* calltype_common_definitions.tmpl will only be executed for each 'calltype' template. */}}
 
 {{define "callGRPC"}}
-func callGRPC{{.MethodName}}(ctx context.Context, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
+func callGRPC{{.MethodName}}(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
+	wg.Done()
 	reply := new({{.FQRespName}})
 	start := time.Now()
 	err := grpc.Invoke(
@@ -83,11 +84,14 @@ func (c *Configuration) {{.UnexportedMethodName}}(ctx context.Context, a *{{.FQR
 
 {{define "callLoop"}}
 	replyChan := make(chan {{.UnexportedTypeName}}, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
 {{- if .PerNodeArg}}
-		go callGRPC{{.MethodName}}(ctx, n, f(*a, n.id), replyChan)
+		go callGRPC{{.MethodName}}(ctx, &wg, n, f(*a, n.id), replyChan)
 {{else}}
-		go callGRPC{{.MethodName}}(ctx, n, a, replyChan)
+		go callGRPC{{.MethodName}}(ctx, &wg, n, a, replyChan)
 {{end -}}
 	}
+	wg.Wait()
 {{end}}

--- a/dev/calltype_correctable_prelim.tmpl
+++ b/dev/calltype_correctable_prelim.tmpl
@@ -169,7 +169,8 @@ type {{.UnexportedTypeName}} struct {
 	}
 }
 
-func callGRPC{{.MethodName}}(ctx context.Context, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
+func callGRPC{{.MethodName}}(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
+	wg.Done()
 	x := New{{.ServName}}Client(node.conn)
 	y, err := x.{{.MethodName}}(ctx, arg)
 	if err != nil {

--- a/dev/calltype_future.tmpl
+++ b/dev/calltype_future.tmpl
@@ -5,6 +5,7 @@
 package {{.PackageName}}
 
 import (
+	"sync"
 	"time"
 
 	"golang.org/x/net/context"

--- a/dev/calltype_quorumcall.tmpl
+++ b/dev/calltype_quorumcall.tmpl
@@ -5,6 +5,7 @@
 package {{.PackageName}}
 
 import (
+	"sync"
 	"time"
 
 	"golang.org/x/net/context"

--- a/testdata/register_golden/register.pb.go
+++ b/testdata/register_golden/register.pb.go
@@ -577,9 +577,12 @@ type readPrelimReply struct {
 
 func (c *Configuration) readPrelim(ctx context.Context, a *ReadRequest, resp *ReadPrelimReply) {
 	replyChan := make(chan readPrelimReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCReadPrelim(ctx, n, a, replyChan)
+		go callGRPCReadPrelim(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*State, 0, c.n*2)
@@ -620,7 +623,8 @@ func (c *Configuration) readPrelim(ctx context.Context, a *ReadRequest, resp *Re
 	}
 }
 
-func callGRPCReadPrelim(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- readPrelimReply) {
+func callGRPCReadPrelim(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *ReadRequest, replyChan chan<- readPrelimReply) {
+	wg.Done()
 	x := NewRegisterClient(node.conn)
 	y, err := x.ReadPrelim(ctx, arg)
 	if err != nil {
@@ -750,9 +754,12 @@ type readCorrectableReply struct {
 
 func (c *Configuration) readCorrectable(ctx context.Context, a *ReadRequest, resp *ReadCorrectableReply) {
 	replyChan := make(chan readCorrectableReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCReadCorrectable(ctx, n, a, replyChan)
+		go callGRPCReadCorrectable(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*State, 0, c.n)
@@ -793,7 +800,8 @@ func (c *Configuration) readCorrectable(ctx context.Context, a *ReadRequest, res
 	}
 }
 
-func callGRPCReadCorrectable(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- readCorrectableReply) {
+func callGRPCReadCorrectable(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *ReadRequest, replyChan chan<- readCorrectableReply) {
+	wg.Done()
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -891,9 +899,12 @@ func (c *Configuration) readFuture(ctx context.Context, a *ReadRequest, resp *Re
 	}
 
 	replyChan := make(chan readFutureReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCReadFuture(ctx, n, a, replyChan)
+		go callGRPCReadFuture(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*State, 0, c.n)
@@ -930,7 +941,8 @@ func (c *Configuration) readFuture(ctx context.Context, a *ReadRequest, resp *Re
 	}
 }
 
-func callGRPCReadFuture(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- readFutureReply) {
+func callGRPCReadFuture(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *ReadRequest, replyChan chan<- readFutureReply) {
+	wg.Done()
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -1026,9 +1038,12 @@ func (c *Configuration) writeFuture(ctx context.Context, a *State, resp *WriteFu
 	}
 
 	replyChan := make(chan writeFutureReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCWriteFuture(ctx, n, a, replyChan)
+		go callGRPCWriteFuture(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*WriteResponse, 0, c.n)
@@ -1065,7 +1080,8 @@ func (c *Configuration) writeFuture(ctx context.Context, a *State, resp *WriteFu
 	}
 }
 
-func callGRPCWriteFuture(ctx context.Context, node *Node, arg *State, replyChan chan<- writeFutureReply) {
+func callGRPCWriteFuture(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *State, replyChan chan<- writeFutureReply) {
+	wg.Done()
 	reply := new(WriteResponse)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -1155,9 +1171,12 @@ func (c *Configuration) read(ctx context.Context, a *ReadRequest) (resp *State, 
 	}
 
 	replyChan := make(chan readReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCRead(ctx, n, a, replyChan)
+		go callGRPCRead(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*State, 0, c.n)
@@ -1189,7 +1208,8 @@ func (c *Configuration) read(ctx context.Context, a *ReadRequest) (resp *State, 
 	}
 }
 
-func callGRPCRead(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- readReply) {
+func callGRPCRead(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *ReadRequest, replyChan chan<- readReply) {
+	wg.Done()
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -1249,9 +1269,12 @@ func (c *Configuration) readCustomReturn(ctx context.Context, a *ReadRequest) (r
 	}
 
 	replyChan := make(chan readCustomReturnReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCReadCustomReturn(ctx, n, a, replyChan)
+		go callGRPCReadCustomReturn(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*State, 0, c.n)
@@ -1283,7 +1306,8 @@ func (c *Configuration) readCustomReturn(ctx context.Context, a *ReadRequest) (r
 	}
 }
 
-func callGRPCReadCustomReturn(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- readCustomReturnReply) {
+func callGRPCReadCustomReturn(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *ReadRequest, replyChan chan<- readCustomReturnReply) {
+	wg.Done()
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -1343,9 +1367,12 @@ func (c *Configuration) write(ctx context.Context, a *State) (resp *WriteRespons
 	}
 
 	replyChan := make(chan writeReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCWrite(ctx, n, a, replyChan)
+		go callGRPCWrite(ctx, &wg, n, a, replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*WriteResponse, 0, c.n)
@@ -1377,7 +1404,8 @@ func (c *Configuration) write(ctx context.Context, a *State) (resp *WriteRespons
 	}
 }
 
-func callGRPCWrite(ctx context.Context, node *Node, arg *State, replyChan chan<- writeReply) {
+func callGRPCWrite(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *State, replyChan chan<- writeReply) {
+	wg.Done()
 	reply := new(WriteResponse)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -1440,9 +1468,12 @@ func (c *Configuration) writePerNode(ctx context.Context, a *State, f func(arg S
 	}
 
 	replyChan := make(chan writePerNodeReply, c.n)
+	var wg sync.WaitGroup
+	wg.Add(c.n)
 	for _, n := range c.nodes {
-		go callGRPCWritePerNode(ctx, n, f(*a, n.id), replyChan)
+		go callGRPCWritePerNode(ctx, &wg, n, f(*a, n.id), replyChan)
 	}
+	wg.Wait()
 
 	var (
 		replyValues = make([]*WriteResponse, 0, c.n)
@@ -1474,7 +1505,8 @@ func (c *Configuration) writePerNode(ctx context.Context, a *State, f func(arg S
 	}
 }
 
-func callGRPCWritePerNode(ctx context.Context, node *Node, arg *State, replyChan chan<- writePerNodeReply) {
+func callGRPCWritePerNode(ctx context.Context, wg *sync.WaitGroup, node *Node, arg *State, replyChan chan<- writePerNodeReply) {
+	wg.Done()
 	reply := new(WriteResponse)
 	start := time.Now()
 	err := grpc.Invoke(


### PR DESCRIPTION
This commit should prevent goroutines that send messages on behalf of QC1 from getting ordered after goroutines that send messages on behalf of QC2.

Further details see issue #44 and a previous #43 solution in an associated PR (in the relab/gorums-dev repo).