### PR TITLE
Deduplicate nodes when creating new configurations

### DIFF
--- a/dev/mgr.go
+++ b/dev/mgr.go
@@ -227,7 +227,16 @@ func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configurati
 	}
 
 	var cnodes []*Node
+	unique := make(map[uint32]struct{})
+	var deduped []uint32
 	for _, nid := range ids {
+		// Ensure that identical ids are only counted once.
+		if _, duplicate := unique[nid]; duplicate {
+			continue
+		}
+		unique[nid] = struct{}{}
+		deduped = append(deduped, nid)
+
 		node, found := m.lookup[nid]
 		if !found {
 			return nil, NodeNotFoundError(nid)
@@ -236,10 +245,10 @@ func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configurati
 	}
 
 	// Node ids are sorted ensure a globally consistent configuration id.
-	sort.Sort(idSlice(ids))
+	sort.Sort(idSlice(deduped))
 
 	h := fnv.New32a()
-	for _, id := range ids {
+	for _, id := range deduped {
 		binary.Write(h, binary.LittleEndian, id)
 	}
 	cid := h.Sum32()

--- a/dev/mgr_test.go
+++ b/dev/mgr_test.go
@@ -6,7 +6,7 @@ import (
 	qc "github.com/relab/gorums/dev"
 )
 
-func TestEqualGlobalConfigurationIDs(t *testing.T) {
+func TestEqualGlobalConfigurationIDsDifferentOrder(t *testing.T) {
 	// Equal set of addresses, but different order.
 	addrsOne := []string{"localhost:8080", "localhost:8081", "localhost:8082"}
 	addrsTwo := []string{"localhost:8081", "localhost:8082", "localhost:8080"}
@@ -33,6 +33,34 @@ func TestEqualGlobalConfigurationIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating config two: %v", err)
 	}
+	if configOne.ID() != configTwo.ID() {
+		t.Errorf("global configuration ids differ, %d != %d",
+			configOne.ID(), configTwo.ID())
+	}
+}
+
+func TestEqualGlobalConfigurationIDsDuplicateID(t *testing.T) {
+	addrs := []string{"localhost:8080", "localhost:8081", "localhost:8082"}
+
+	mgr, err := qc.NewManager(addrs, qc.WithNoConnect())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids := mgr.NodeIDs()
+
+	// Create a configuration with all ids available in the manager.
+	configOne, err := mgr.NewConfiguration(ids, &MajorityQSpec{})
+	if err != nil {
+		t.Fatalf("error creating config one: %v", err)
+	}
+	// Create a configuration with all ids available in the manager and a duplicate.
+	configTwo, err := mgr.NewConfiguration(append(ids, ids[0]), &MajorityQSpec{})
+	if err != nil {
+		t.Fatalf("error creating config two: %v", err)
+	}
+
+	// Global ids should be equal.
 	if configOne.ID() != configTwo.ID() {
 		t.Errorf("global configuration ids differ, %d != %d",
 			configOne.ID(), configTwo.ID())


### PR DESCRIPTION
Manager.NewConfiguration returns a configuration with `node1,node2,node2` given ids `id1,id2,id2`.
I would like to change this function call to return a configuration with `node1,node2` so that it's easier to make idempotent add operations.
(Alternatively, disallow duplicate node ids and return an error as is done with gorums.NewManager.)