### PR TITLE
Fix nil values being added to the reply slice

### DIFF
--- a/dev/calltype_common_definitions.tmpl
+++ b/dev/calltype_common_definitions.tmpl
@@ -3,11 +3,6 @@
 
 {{define "callGRPC"}}
 func callGRPC{{.MethodName}}(ctx context.Context, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- {{.UnexportedTypeName}}{node.id, nil, nil}
-		return
-	}
 	reply := new({{.FQRespName}})
 	start := time.Now()
 	err := grpc.Invoke(
@@ -87,12 +82,16 @@ func (c *Configuration) {{.UnexportedMethodName}}(ctx context.Context, a *{{.FQR
 {{end}}
 
 {{define "callLoop"}}
-	replyChan := make(chan {{.UnexportedTypeName}}, c.n)
-	for _, n := range c.nodes {
+  expected := c.n
+  replyChan := make(chan {{.UnexportedTypeName}}, expected)
+  for _, n := range c.nodes {
 {{- if .PerNodeArg}}
-		go callGRPC{{.MethodName}}(ctx, n, f(*a, n.id), replyChan)
-{{else}}
-		go callGRPC{{.MethodName}}(ctx, n, a, replyChan)
+    a := f(*a, n.id)
+    if a == nil {
+      expected--
+      continue
+    }
 {{end -}}
-	}
+    go callGRPC{{.MethodName}}(ctx, n, a, replyChan)
+  }
 {{end}}

--- a/dev/calltype_correctable.tmpl
+++ b/dev/calltype_correctable.tmpl
@@ -175,7 +175,7 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}

--- a/dev/calltype_correctable_gen.go
+++ b/dev/calltype_correctable_gen.go
@@ -123,7 +123,8 @@ func (c *Configuration) readCorrectable(ctx context.Context, a *ReadRequest, res
 		}()
 	}
 
-	replyChan := make(chan internalState, c.n)
+	expected := c.n
+	replyChan := make(chan internalState, expected)
 	for _, n := range c.nodes {
 		go callGRPCReadCorrectable(ctx, n, a, replyChan)
 	}
@@ -171,11 +172,6 @@ func (c *Configuration) readCorrectable(ctx context.Context, a *ReadRequest, res
 }
 
 func callGRPCReadCorrectable(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- internalState) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- internalState{node.id, nil, nil}
-		return
-	}
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(

--- a/dev/calltype_correctable_gen.go
+++ b/dev/calltype_correctable_gen.go
@@ -164,7 +164,7 @@ func (c *Configuration) readCorrectable(ctx context.Context, a *ReadRequest, res
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}

--- a/dev/calltype_correctable_stream.tmpl
+++ b/dev/calltype_correctable_stream.tmpl
@@ -171,7 +171,7 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 			return
 		}
 
-		if errCount == c.n { // Can't rely on reply count.
+		if errCount == expected { // Can't rely on reply count.
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}
@@ -179,11 +179,6 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 }
 
 func callGRPC{{.MethodName}}(ctx context.Context, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- {{.UnexportedTypeName}}{node.id, nil, nil}
-		return
-	}
 	x := New{{.ServName}}Client(node.conn)
 	y, err := x.{{.MethodName}}(ctx, arg)
 	if err != nil {

--- a/dev/calltype_correctable_stream_gen.go
+++ b/dev/calltype_correctable_stream_gen.go
@@ -120,7 +120,8 @@ func (c *Configuration) readCorrectableStream(ctx context.Context, a *ReadReques
 		}()
 	}
 
-	replyChan := make(chan internalState, c.n)
+	expected := c.n
+	replyChan := make(chan internalState, expected)
 	for _, n := range c.nodes {
 		go callGRPCReadCorrectableStream(ctx, n, a, replyChan)
 	}

--- a/dev/calltype_correctable_stream_gen.go
+++ b/dev/calltype_correctable_stream_gen.go
@@ -161,7 +161,7 @@ func (c *Configuration) readCorrectableStream(ctx context.Context, a *ReadReques
 			return
 		}
 
-		if errCount == c.n { // Can't rely on reply count.
+		if errCount == expected { // Can't rely on reply count.
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}
@@ -169,11 +169,6 @@ func (c *Configuration) readCorrectableStream(ctx context.Context, a *ReadReques
 }
 
 func callGRPCReadCorrectableStream(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- internalState) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- internalState{node.id, nil, nil}
-		return
-	}
 	x := NewStorageClient(node.conn)
 	y, err := x.ReadCorrectableStream(ctx, arg)
 	if err != nil {

--- a/dev/calltype_future.tmpl
+++ b/dev/calltype_future.tmpl
@@ -118,7 +118,7 @@ func (f *{{.TypeName}}) Done() bool {
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.{{.CustomRespName}}, resp.err = reply, QuorumCallError{"incomplete call", errCount, len(replyValues)}
 			return
 		}

--- a/dev/calltype_future_gen.go
+++ b/dev/calltype_future_gen.go
@@ -75,7 +75,8 @@ func (c *Configuration) readFuture(ctx context.Context, a *ReadRequest, resp *Fu
 		}()
 	}
 
-	replyChan := make(chan internalState, c.n)
+	expected := c.n
+	replyChan := make(chan internalState, expected)
 	for _, n := range c.nodes {
 		go callGRPCReadFuture(ctx, n, a, replyChan)
 	}
@@ -116,11 +117,6 @@ func (c *Configuration) readFuture(ctx context.Context, a *ReadRequest, resp *Fu
 }
 
 func callGRPCReadFuture(ctx context.Context, node *Node, arg *ReadRequest, replyChan chan<- internalState) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- internalState{node.id, nil, nil}
-		return
-	}
 	reply := new(State)
 	start := time.Now()
 	err := grpc.Invoke(
@@ -200,7 +196,8 @@ func (c *Configuration) writeFuture(ctx context.Context, a *State, resp *FutureW
 		}()
 	}
 
-	replyChan := make(chan internalWriteResponse, c.n)
+	expected := c.n
+	replyChan := make(chan internalWriteResponse, expected)
 	for _, n := range c.nodes {
 		go callGRPCWriteFuture(ctx, n, a, replyChan)
 	}
@@ -241,11 +238,6 @@ func (c *Configuration) writeFuture(ctx context.Context, a *State, resp *FutureW
 }
 
 func callGRPCWriteFuture(ctx context.Context, node *Node, arg *State, replyChan chan<- internalWriteResponse) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- internalWriteResponse{node.id, nil, nil}
-		return
-	}
 	reply := new(WriteResponse)
 	start := time.Now()
 	err := grpc.Invoke(

--- a/dev/calltype_future_gen.go
+++ b/dev/calltype_future_gen.go
@@ -109,7 +109,7 @@ func (c *Configuration) readFuture(ctx context.Context, a *ReadRequest, resp *Fu
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.State, resp.err = reply, QuorumCallError{"incomplete call", errCount, len(replyValues)}
 			return
 		}
@@ -230,7 +230,7 @@ func (c *Configuration) writeFuture(ctx context.Context, a *State, resp *FutureW
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.WriteResponse, resp.err = reply, QuorumCallError{"incomplete call", errCount, len(replyValues)}
 			return
 		}

--- a/dev/calltype_quorumcall.tmpl
+++ b/dev/calltype_quorumcall.tmpl
@@ -55,7 +55,7 @@ func (c *Configuration) {{.UnexportedMethodName}}(ctx context.Context, a *{{.FQR
 	{{template "callLoop" .}}
 
 	var (
-		replyValues = make([]*{{.FQRespName}}, 0, c.n)
+		replyValues = make([]*{{.FQRespName}}, 0, expected)
 		errCount    int
 		quorum      bool
 	)
@@ -82,7 +82,7 @@ func (c *Configuration) {{.UnexportedMethodName}}(ctx context.Context, a *{{.FQR
 			return resp, QuorumCallError{ctx.Err().Error(), errCount, len(replyValues)}
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			return resp, QuorumCallError{"incomplete call", errCount, len(replyValues)}
 		}
 	}

--- a/dev/config_qc_qspecs_test.go
+++ b/dev/config_qc_qspecs_test.go
@@ -222,14 +222,7 @@ func (sqs *StorageByTimestampQSpec) WritePerNodeQF(replies []*qc.WriteResponse) 
 	if len(replies) < sqs.wq {
 		return nil, false
 	}
-	// Note: This quorum function is designed to tolerate nil values, since some nodes
-	// may not actually be invoked, but simply ignored with a nil from the perNodeArg function.
-	for _, reply := range replies {
-		if reply != nil {
-			return reply, true
-		}
-	}
-	return nil, false
+	return replies[0], true
 }
 
 type NeverQSpec struct{}

--- a/dev/config_qc_test.go
+++ b/dev/config_qc_test.go
@@ -130,6 +130,15 @@ func TestBasicStorage(t *testing.T) {
 	for _, m := range nodes {
 		t.Logf("%v", m)
 	}
+
+	// Do read call with nil argument
+	rreply, err = config.Read(ctx, nil)
+	if err == nil {
+		t.Fatalf("expected error, not nil")
+	}
+	if rreply != nil {
+		t.Fatalf("expected nil reply, not: %v", rreply)
+	}
 }
 
 func TestSingleServerRPC(t *testing.T) {
@@ -932,6 +941,14 @@ func TestPerNodeArg(t *testing.T) {
 	t.Logf("wreply: %v\n", wreply)
 	if !wreply.New {
 		t.Error("write reply was not marked as new")
+	}
+
+	wreply, err = config.WritePerNode(ctx, nil, perNodeArgNil)
+	if err == nil {
+		t.Fatalf("expected error, not nil")
+	}
+	if wreply != nil {
+		t.Fatalf("expected nil reply, not: %v", wreply)
 	}
 }
 

--- a/dev/config_qc_test.go
+++ b/dev/config_qc_test.go
@@ -131,13 +131,18 @@ func TestBasicStorage(t *testing.T) {
 		t.Logf("%v", m)
 	}
 
+	// defer func() {
+	// 	if r := recover(); r == nil {
+	// 		t.Fatalf("expected panic for nil argument to Read function")
+	// 	}
+	// }()
 	// Do read call with nil argument
 	rreply, err = config.Read(ctx, nil)
-	if err == nil {
-		t.Fatalf("expected error, not nil")
-	}
 	if rreply != nil {
-		t.Fatalf("expected nil reply, not: %v", rreply)
+		t.Logf("got reply: %v", rreply)
+	}
+	if err != nil {
+		t.Logf("got err: %v", err)
 	}
 }
 
@@ -867,8 +872,8 @@ func TestPerNodeArg(t *testing.T) {
 	// Get all all available node ids
 	ids := mgr.NodeIDs()
 
-	// Quorum spec: rq=2. wq=3, n=3, sort by timestamp.
-	qspec := NewStorageByTimestampQSpec(2, len(ids))
+	// Quorum spec: rq=2. wq=2, n=3, sort by timestamp.
+	qspec := NewStorageByTimestampQSpec(2, 2)
 
 	config, err := mgr.NewConfiguration(ids, qspec)
 	if err != nil {
@@ -943,13 +948,12 @@ func TestPerNodeArg(t *testing.T) {
 		t.Error("write reply was not marked as new")
 	}
 
-	wreply, err = config.WritePerNode(ctx, nil, perNodeArgNil)
-	if err == nil {
-		t.Fatalf("expected error, not nil")
-	}
-	if wreply != nil {
-		t.Fatalf("expected nil reply, not: %v", wreply)
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic for nil argument to WritePerNode function")
+		}
+	}()
+	config.WritePerNode(ctx, nil, perNodeArgNil)
 }
 
 ///////////////////////////////////////////////////////////////

--- a/plugins/gorums/templates.go
+++ b/plugins/gorums/templates.go
@@ -279,7 +279,7 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}
@@ -465,7 +465,7 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 			return
 		}
 
-		if errCount == c.n { // Can't rely on reply count.
+		if errCount == expected { // Can't rely on reply count.
 			resp.set(reply, clevel, QuorumCallError{"incomplete call", errCount, len(replyValues)}, true)
 			return
 		}
@@ -473,11 +473,6 @@ func (c *{{.TypeName}}) set(reply *{{.FQCustomRespName}}, level int, err error, 
 }
 
 func callGRPC{{.MethodName}}(ctx context.Context, node *Node, arg *{{.FQReqName}}, replyChan chan<- {{.UnexportedTypeName}}) {
-	if arg == nil {
-		// send a nil reply to the for-select-loop
-		replyChan <- {{.UnexportedTypeName}}{node.id, nil, nil}
-		return
-	}
 	x := New{{.ServName}}Client(node.conn)
 	y, err := x.{{.MethodName}}(ctx, arg)
 	if err != nil {
@@ -676,7 +671,7 @@ func (f *{{.TypeName}}) Done() bool {
 			return
 		}
 
-		if errCount+len(replyValues) == c.n {
+		if errCount+len(replyValues) == expected {
 			resp.{{.CustomRespName}}, resp.err = reply, QuorumCallError{"incomplete call", errCount, len(replyValues)}
 			return
 		}


### PR DESCRIPTION
TestPerNodeArg is left failing to demonstrate the issue.
The test should fail while in `master` is succeeds.
I'll fix it when we agree whether this is a good solution.
See #35.