### PR TITLE
Sorting based on Port number

### DIFF
--- a/dev/node_func.go
+++ b/dev/node_func.go
@@ -33,12 +33,22 @@ func (n *Node) Port() string {
 }
 
 func (n *Node) String() string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return fmt.Sprintf(
-		"node %d | addr: %s | latency: %v",
-		n.id, n.addr, n.latency,
-	)
+	if n != nil {
+		return fmt.Sprintf("addr: %s", n.addr)
+	}
+	return ""
+}
+
+func (n *Node) FullString() string {
+	if n != nil {
+		n.mu.Lock()
+		defer n.mu.Unlock()
+		return fmt.Sprintf(
+			"node %d | addr: %s | latency: %v",
+			n.id, n.addr, n.latency,
+		)
+	}
+	return ""
 }
 
 func (n *Node) setLastErr(err error) {

--- a/dev/node_func.go
+++ b/dev/node_func.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"time"
 )
 
@@ -141,6 +142,14 @@ func (ms *MultiSorter) Less(i, j int) bool {
 // ID sorts nodes by their identifier in increasing order.
 var ID = func(n1, n2 *Node) bool {
 	return n1.id < n2.id
+}
+
+// Port sorts nodes by their port number in increasing order.
+// Warning: This function may be removed in the future.
+var Port = func(n1, n2 *Node) bool {
+	p1, _ := strconv.Atoi(n1.Port())
+	p2, _ := strconv.Atoi(n2.Port())
+	return p1 < p2
 }
 
 // Latency sorts nodes by latency in increasing order. Latencies less then

--- a/dev/node_func.go
+++ b/dev/node_func.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const nilAngleString = "<nil>"
+
 // ID returns the ID of n.
 func (n *Node) ID() uint32 {
 	if n != nil {
@@ -21,7 +23,7 @@ func (n *Node) Address() string {
 	if n != nil {
 		return n.addr
 	}
-	return ""
+	return nilAngleString
 }
 
 // Port returns network port of n.
@@ -30,14 +32,14 @@ func (n *Node) Port() string {
 		_, port, _ := net.SplitHostPort(n.addr)
 		return port
 	}
-	return ""
+	return nilAngleString
 }
 
 func (n *Node) String() string {
 	if n != nil {
 		return fmt.Sprintf("addr: %s", n.addr)
 	}
-	return ""
+	return nilAngleString
 }
 
 func (n *Node) FullString() string {
@@ -49,7 +51,7 @@ func (n *Node) FullString() string {
 			n.id, n.addr, n.latency,
 		)
 	}
-	return ""
+	return nilAngleString
 }
 
 func (n *Node) setLastErr(err error) {

--- a/plugins/gorums/static.go
+++ b/plugins/gorums/static.go
@@ -442,12 +442,22 @@ func (n *Node) Port() string {
 }
 
 func (n *Node) String() string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return fmt.Sprintf(
-		"node %d | addr: %s | latency: %v",
-		n.id, n.addr, n.latency,
-	)
+	if n != nil {
+		return fmt.Sprintf("addr: %s", n.addr)
+	}
+	return ""
+}
+
+func (n *Node) FullString() string {
+	if n != nil {
+		n.mu.Lock()
+		defer n.mu.Unlock()
+		return fmt.Sprintf(
+			"node %d | addr: %s | latency: %v",
+			n.id, n.addr, n.latency,
+		)
+	}
+	return ""
 }
 
 func (n *Node) setLastErr(err error) {

--- a/plugins/gorums/static.go
+++ b/plugins/gorums/static.go
@@ -12,6 +12,7 @@ var staticImports = []string{
 	"sort",
 	"sync",
 	"strings",
+	"strconv",
 	"net",
 	"log",
 	"hash/fnv",
@@ -550,6 +551,14 @@ func (ms *MultiSorter) Less(i, j int) bool {
 // ID sorts nodes by their identifier in increasing order.
 var ID = func(n1, n2 *Node) bool {
 	return n1.id < n2.id
+}
+
+// Port sorts nodes by their port number in increasing order.
+// Warning: This function may be removed in the future.
+var Port = func(n1, n2 *Node) bool {
+	p1, _ := strconv.Atoi(n1.Port())
+	p2, _ := strconv.Atoi(n2.Port())
+	return p1 < p2
 }
 
 // Latency sorts nodes by latency in increasing order. Latencies less then


### PR DESCRIPTION
This is useful for some stuff we are doing with localhost nodes for Rui's project. However, I'm not sure we want to keep it in the future, so I've added a Warning that it may be removed again later.

Note that I'm knowingly ignoring the errors that could occur here. If we want to keep the function in the future, we should consider a more appropriate handling of the errors.