### PR TITLE
replaced deprecated grpc.WithTimeout() for use in the tests

### DIFF
--- a/dev/config_qc_secure_test.go
+++ b/dev/config_qc_secure_test.go
@@ -119,7 +119,7 @@ func TestSecureStorage(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(servers.addrs(), dialOpts)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/dev/config_qc_test.go
+++ b/dev/config_qc_test.go
@@ -71,13 +71,10 @@ func TestBasicStorage(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgrOpts := []qc.ManagerOption{
+	mgr, err := qc.NewManager(servers.addrs(),
 		dialOpts,
 		qc.WithTracing(),
-	}
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		mgrOpts...,
+		qc.WithDialTimeout(time.Second),
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -164,10 +161,7 @@ func TestSingleServerRPC(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -214,10 +208,7 @@ func TestExitHandleRepliesLoop(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -268,10 +259,7 @@ func TestSlowStorage(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -315,10 +303,7 @@ func TestBasicStorageUsingFuture(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -390,10 +375,7 @@ func TestBasicStorageWithWriteAsync(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -465,7 +447,6 @@ func TestBasicStorageWithWriteAsync(t *testing.T) {
 }
 
 func TestManagerClose(t *testing.T) {
-
 	servers, dialOpts, stopGrpcServe, closeListeners := setup(
 		t,
 		[]storageServer{
@@ -479,10 +460,7 @@ func TestManagerClose(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -517,10 +495,7 @@ func TestQuorumCallCancel(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -570,10 +545,7 @@ func TestBasicCorrectable(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -631,10 +603,7 @@ func TestCorrectableWithLevels(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -727,10 +696,7 @@ func TestCorrectableStream(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -859,13 +825,10 @@ func TestPerNodeArg(t *testing.T) {
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgrOpts := []qc.ManagerOption{
+	mgr, err := qc.NewManager(servers.addrs(),
 		dialOpts,
 		qc.WithTracing(),
-	}
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		mgrOpts...,
+		qc.WithDialTimeout(time.Second),
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -1088,10 +1051,7 @@ func benchmarkRead(b *testing.B, psize, rq, n int, parallel, future, remote bool
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		b.Fatalf("%v", err)
 	}
@@ -1218,10 +1178,7 @@ func benchmarkWrite(b *testing.B, psize, wq, n int, parallel, future, remote boo
 	defer closeListeners(allServers)
 	defer stopGrpcServe(allServers)
 
-	mgr, err := qc.NewManager(
-		servers.addrs(),
-		dialOpts,
-	)
+	mgr, err := qc.NewManager(servers.addrs(), dialOpts, qc.WithDialTimeout(time.Second))
 	if err != nil {
 		b.Fatalf("%v", err)
 	}
@@ -1366,7 +1323,6 @@ func setup(t testing.TB, storServers []storageServer, remote, secure bool) (stor
 
 	grpcOpts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithTimeout(time.Second),
 	}
 	if secure {
 		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(clientCredentials(t)))

--- a/dev/mgr.go
+++ b/dev/mgr.go
@@ -111,7 +111,7 @@ func (m *Manager) connectAll() error {
 	}
 
 	for _, node := range m.nodes {
-		err := node.connect(m.opts.grpcDialOpts...)
+		err := node.connect(m.opts)
 		if err != nil {
 			if m.eventLog != nil {
 				m.eventLog.Errorf("connect failed, error connecting to node %s, error: %v", node.addr, err)

--- a/dev/node.tmpl
+++ b/dev/node.tmpl
@@ -39,9 +39,11 @@ type Node struct {
 	latency time.Duration
 }
 
-func (n *Node) connect(opts ...grpc.DialOption) error {
-  	var err error
-	n.conn, err = grpc.Dial(n.addr, opts...)
+func (n *Node) connect(opts managerOptions) error {
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), opts.nodeDialTimeout)
+	defer cancel()
+	n.conn, err = grpc.DialContext(ctx, n.addr, opts.grpcDialOpts...)
 	if err != nil {
 		return fmt.Errorf("dialing node failed: %v", err)
 	}

--- a/dev/node_gen.go
+++ b/dev/node_gen.go
@@ -32,9 +32,11 @@ type Node struct {
 	latency time.Duration
 }
 
-func (n *Node) connect(opts ...grpc.DialOption) error {
+func (n *Node) connect(opts managerOptions) error {
 	var err error
-	n.conn, err = grpc.Dial(n.addr, opts...)
+	ctx, cancel := context.WithTimeout(context.Background(), opts.nodeDialTimeout)
+	defer cancel()
+	n.conn, err = grpc.DialContext(ctx, n.addr, opts.grpcDialOpts...)
 	if err != nil {
 		return fmt.Errorf("dialing node failed: %v", err)
 	}

--- a/dev/opts.go
+++ b/dev/opts.go
@@ -2,23 +2,32 @@ package dev
 
 import (
 	"log"
+	"time"
 
 	"google.golang.org/grpc"
 )
 
 type managerOptions struct {
-	grpcDialOpts []grpc.DialOption
-	logger       *log.Logger
-	noConnect    bool
-	trace        bool
+	grpcDialOpts    []grpc.DialOption
+	nodeDialTimeout time.Duration
+	logger          *log.Logger
+	noConnect       bool
+	trace           bool
 }
 
 // ManagerOption provides a way to set different options on a new Manager.
 type ManagerOption func(*managerOptions)
 
+// WithDialTimeout returns a ManagerOption which is used to set the dial
+// context timeout to be used when initially connecting to each node in its pool.
+func WithDialTimeout(timeout time.Duration) ManagerOption {
+	return func(o *managerOptions) {
+		o.nodeDialTimeout = timeout
+	}
+}
+
 // WithGrpcDialOptions returns a ManagerOption which sets any gRPC dial options
-// the Manager should use when initially connecting to each node in its
-// pool.
+// the Manager should use when initially connecting to each node in its pool.
 func WithGrpcDialOptions(opts ...grpc.DialOption) ManagerOption {
 	return func(o *managerOptions) {
 		o.grpcDialOpts = opts

--- a/plugins/gorums/static.go
+++ b/plugins/gorums/static.go
@@ -249,7 +249,7 @@ func (m *Manager) connectAll() error {
 	}
 
 	for _, node := range m.nodes {
-		err := node.connect(m.opts.grpcDialOpts...)
+		err := node.connect(m.opts)
 		if err != nil {
 			if m.eventLog != nil {
 				m.eventLog.Errorf("connect failed, error connecting to node %s, error: %v", node.addr, err)
@@ -588,6 +588,7 @@ var Error = func(n1, n2 *Node) bool {
 
 type managerOptions struct {
 	grpcDialOpts	[]grpc.DialOption
+	nodeDialTimeout	time.Duration
 	logger		*log.Logger
 	noConnect	bool
 	trace		bool
@@ -596,9 +597,16 @@ type managerOptions struct {
 // ManagerOption provides a way to set different options on a new Manager.
 type ManagerOption func(*managerOptions)
 
+// WithDialTimeout returns a ManagerOption which is used to set the dial
+// context timeout to be used when initially connecting to each node in its pool.
+func WithDialTimeout(timeout time.Duration) ManagerOption {
+	return func(o *managerOptions) {
+		o.nodeDialTimeout = timeout
+	}
+}
+
 // WithGrpcDialOptions returns a ManagerOption which sets any gRPC dial options
-// the Manager should use when initially connecting to each node in its
-// pool.
+// the Manager should use when initially connecting to each node in its pool.
 func WithGrpcDialOptions(opts ...grpc.DialOption) ManagerOption {
 	return func(o *managerOptions) {
 		o.grpcDialOpts = opts

--- a/plugins/gorums/templates.go
+++ b/plugins/gorums/templates.go
@@ -847,9 +847,11 @@ type Node struct {
 	latency time.Duration
 }
 
-func (n *Node) connect(opts ...grpc.DialOption) error {
-  	var err error
-	n.conn, err = grpc.Dial(n.addr, opts...)
+func (n *Node) connect(opts managerOptions) error {
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), opts.nodeDialTimeout)
+	defer cancel()
+	n.conn, err = grpc.DialContext(ctx, n.addr, opts.grpcDialOpts...)
 	if err != nil {
 		return fmt.Errorf("dialing node failed: %v", err)
 	}


### PR DESCRIPTION
this was a fairly extensive change since we pass in these grpc
options into the NewManager() function, and we use this a lot.