### PR TITLE
Use a context that doesn't timeout for creating streams

### DIFF
--- a/cmd/protoc-gen-gorums/dev/node.go
+++ b/cmd/protoc-gen-gorums/dev/node.go
@@ -37,7 +37,7 @@ func (n *Node) connect(opts managerOptions) error {
 	if err != nil {
 		return fmt.Errorf("dialing node failed: %w", err)
 	}
-	return n.connectStream(ctx) // call generated method
+	return n.connectStream() // call generated method
 }
 
 // close this node for further calls and optionally stream.

--- a/cmd/protoc-gen-gorums/dev/zorums_node_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_node_gorums.pb.go
@@ -13,13 +13,13 @@ type nodeServices struct {
 	readMulticast2Client ReaderService_ReadMulticast2Client
 }
 
-func (n *Node) connectStream(ctx context.Context) (err error) {
+func (n *Node) connectStream() (err error) {
 	n.ReaderServiceClient = NewReaderServiceClient(n.conn)
-	n.readMulticastClient, err = n.ReaderServiceClient.ReadMulticast(ctx)
+	n.readMulticastClient, err = n.ReaderServiceClient.ReadMulticast(context.Background())
 	if err != nil {
 		return fmt.Errorf("stream creation failed: %v", err)
 	}
-	n.readMulticast2Client, err = n.ReaderServiceClient.ReadMulticast2(ctx)
+	n.readMulticast2Client, err = n.ReaderServiceClient.ReadMulticast2(context.Background())
 	if err != nil {
 		return fmt.Errorf("stream creation failed: %v", err)
 	}

--- a/cmd/protoc-gen-gorums/internalgorums/template_node.go
+++ b/cmd/protoc-gen-gorums/internalgorums/template_node.go
@@ -17,9 +17,9 @@ type nodeServices struct {
 `
 
 var nodeConnectStream = `
-{{$context := use "context.Context" .GenFile}}
+{{$context := use "context.Background" .GenFile}}
 {{$errorf := use "fmt.Errorf" .GenFile}}
-func (n *Node) connectStream(ctx {{$context}}) (err error) {
+func (n *Node) connectStream() (err error) {
 	{{- range .Services}}
 	n.{{.GoName}}Client = New{{.GoName}}Client(n.conn)
 	{{- end}}
@@ -27,10 +27,10 @@ func (n *Node) connectStream(ctx {{$context}}) (err error) {
 	{{- range .Services -}}
 	{{$serviceName := .GoName}}
 	{{- range streamMethods .Methods}}
-	n.{{unexport .GoName}}Client, err = n.{{$serviceName}}Client.{{.GoName}}(ctx)
-  	if err != nil {
-  		return {{$errorf}}("stream creation failed: %v", err)
-  	}
+	n.{{unexport .GoName}}Client, err = n.{{$serviceName}}Client.{{.GoName}}({{$context}}())
+	if err != nil {
+		return {{$errorf}}("stream creation failed: %v", err)
+	}
 	{{- end -}}
 	{{end}}
 	return nil

--- a/cmd/protoc-gen-gorums/internalgorums/template_static.go
+++ b/cmd/protoc-gen-gorums/internalgorums/template_static.go
@@ -436,7 +436,7 @@ func (n *Node) connect(opts managerOptions) error {
 	if err != nil {
 		return fmt.Errorf("dialing node failed: %w", err)
 	}
-	return n.connectStream(ctx) // call generated method
+	return n.connectStream() // call generated method
 }
 
 // close this node for further calls and optionally stream.


### PR DESCRIPTION
The streams should stay up until the Node is closed.