### PR TITLE
Fix leaked goroutines in orderedNodeStream sendMsgs

### DIFF
--- a/cmd/protoc-gen-gorums/gengorums/template_static.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_static.go
@@ -796,13 +796,19 @@ func (s *orderedNodeStream) connectOrderedStream(ctx context.Context, conn *grpc
 	if err != nil {
 		return err
 	}
-	go s.sendMsgs()
+	go s.sendMsgs(ctx)
 	go s.recvMsgs(ctx)
 	return nil
 }
 
-func (s *orderedNodeStream) sendMsgs() {
-	for req := range s.sendQ {
+func (s *orderedNodeStream) sendMsgs(ctx context.Context) {
+	var req *ordering.Message
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req = <-s.sendQ:
+		}
 		// return error if stream is broken
 		if s.streamBroken {
 			err := status.Errorf(codes.Unavailable, "stream is down")


### PR DESCRIPTION
The `sendQ` channel is never closed, so we can use a context to close the goroutines instead.