### PR TITLE
Add an option to control the size of sendQ buffer

### DIFF
--- a/cmd/protoc-gen-gorums/dev/mgr.go
+++ b/cmd/protoc-gen-gorums/dev/mgr.go
@@ -43,9 +43,7 @@ func NewManager(nodeAddrs []string, opts ...ManagerOption) (*Manager, error) {
 		lookup:       make(map[uint32]*Node),
 		configs:      make(map[uint32]*Configuration),
 		receiveQueue: newReceiveQueue(),
-		opts: managerOptions{
-			backoff: backoff.DefaultConfig,
-		},
+		opts:         newManagerOptions(),
 	}
 
 	for _, opt := range opts {
@@ -110,7 +108,7 @@ func (m *Manager) createNode(addr string) (*Node, error) {
 		addr:    tcpAddr.String(),
 		latency: -1 * time.Second,
 	}
-	node.createOrderedStream(m.receiveQueue, m.opts.backoff)
+	node.createOrderedStream(m.receiveQueue, m.opts)
 
 	return node, nil
 }

--- a/cmd/protoc-gen-gorums/dev/node.go
+++ b/cmd/protoc-gen-gorums/dev/node.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/relab/gorums/ordering"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 )
 
 const nilAngleString = "<nil>"
@@ -35,12 +34,12 @@ type Node struct {
 	nodeServices
 }
 
-func (n *Node) createOrderedStream(rq *receiveQueue, backoff backoff.Config) {
+func (n *Node) createOrderedStream(rq *receiveQueue, opts managerOptions) {
 	n.orderedNodeStream = &orderedNodeStream{
 		receiveQueue: rq,
-		sendQ:        make(chan *ordering.Message),
+		sendQ:        make(chan *ordering.Message, opts.sendBuffer),
 		node:         n,
-		backoff:      backoff,
+		backoff:      opts.backoff,
 		rand:         rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }

--- a/cmd/protoc-gen-gorums/dev/opts.go
+++ b/cmd/protoc-gen-gorums/dev/opts.go
@@ -15,6 +15,14 @@ type managerOptions struct {
 	noConnect       bool
 	trace           bool
 	backoff         backoff.Config
+	sendBuffer      uint
+}
+
+func newManagerOptions() managerOptions {
+	return managerOptions{
+		backoff:    backoff.DefaultConfig,
+		sendBuffer: 0,
+	}
 }
 
 // ManagerOption provides a way to set different options on a new Manager.
@@ -65,5 +73,14 @@ func WithTracing() ManagerOption {
 func WithBackoff(backoff backoff.Config) ManagerOption {
 	return func(o *managerOptions) {
 		o.backoff = backoff
+	}
+}
+
+// WithSendBufferSize allows for changing the size of the send buffer used by Gorums.
+// A larger buffer might achieve higher throughput for asynchronous calltypes, but at
+// the cost of latency.
+func WithSendBufferSize(size uint) ManagerOption {
+	return func(o *managerOptions) {
+		o.sendBuffer = size
 	}
 }

--- a/cmd/protoc-gen-gorums/gengorums/template_static.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_static.go
@@ -215,9 +215,7 @@ func NewManager(nodeAddrs []string, opts ...ManagerOption) (*Manager, error) {
 		lookup:       make(map[uint32]*Node),
 		configs:      make(map[uint32]*Configuration),
 		receiveQueue: newReceiveQueue(),
-		opts: managerOptions{
-			backoff: backoff.DefaultConfig,
-		},
+		opts:         newManagerOptions(),
 	}
 
 	for _, opt := range opts {
@@ -282,7 +280,7 @@ func (m *Manager) createNode(addr string) (*Node, error) {
 		addr:    tcpAddr.String(),
 		latency: -1 * time.Second,
 	}
-	node.createOrderedStream(m.receiveQueue, m.opts.backoff)
+	node.createOrderedStream(m.receiveQueue, m.opts)
 
 	return node, nil
 }
@@ -485,12 +483,12 @@ type Node struct {
 	nodeServices
 }
 
-func (n *Node) createOrderedStream(rq *receiveQueue, backoff backoff.Config) {
+func (n *Node) createOrderedStream(rq *receiveQueue, opts managerOptions) {
 	n.orderedNodeStream = &orderedNodeStream{
 		receiveQueue: rq,
-		sendQ:        make(chan *ordering.Message),
+		sendQ:        make(chan *ordering.Message, opts.sendBuffer),
 		node:         n,
-		backoff:      backoff,
+		backoff:      opts.backoff,
 		rand:         rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
@@ -697,6 +695,14 @@ type managerOptions struct {
 	noConnect       bool
 	trace           bool
 	backoff         backoff.Config
+	sendBuffer      uint
+}
+
+func newManagerOptions() managerOptions {
+	return managerOptions{
+		backoff:    backoff.DefaultConfig,
+		sendBuffer: 0,
+	}
 }
 
 // ManagerOption provides a way to set different options on a new Manager.
@@ -747,6 +753,15 @@ func WithTracing() ManagerOption {
 func WithBackoff(backoff backoff.Config) ManagerOption {
 	return func(o *managerOptions) {
 		o.backoff = backoff
+	}
+}
+
+// WithSendBufferSize allows for changing the size of the send buffer used by Gorums.
+// A larger buffer might achieve higher throughput for asynchronous calltypes, but at
+// the cost of latency.
+func WithSendBufferSize(size uint) ManagerOption {
+	return func(o *managerOptions) {
+		o.sendBuffer = size
 	}
 }
 


### PR DESCRIPTION
In calltypes using `NodeStream`, the size of the buffer in the `sendQ` channel can have a major impact on performance for some calltypes. In particular, a small buffer yields lower latency, while a larger buffer yields higher throughput.

This PR adds a new `ManagerOption`, `WithSendBufferSize`, that gives control over the size of the buffer on this channel.

I have done some benchmarks comparing the new implementation of Multicast (#65) with the old version, using different buffer sizes. The benchmarks were performed on some of the `pitter` machines at UiS, with 1 client and 4 servers.

![throughput](https://user-images.githubusercontent.com/10762082/84387939-0d326d80-abf4-11ea-9eb7-110bf8264e6f.png)
![latency](https://user-images.githubusercontent.com/10762082/84387950-115e8b00-abf4-11ea-9aa1-53ba6ef8ad57.png)

Raw data:

Baseline (old multicast):

```
Benchmark    Througput           Latency    Std.dev    Client+Servers                    
Multicast    86596.45 ops/sec    0.44 ms    0.82 ms    3101 B/op         61 allocs/op 
```

New Multicast:

```
Buffer size: 0
Benchmark    Througput           Latency    Std.dev    Client+Servers                    
Multicast    55255.25 ops/sec    0.27 ms    0.51 ms    4399 B/op         83 allocs/op    

Buffer size: 1
Benchmark    Througput           Latency    Std.dev    Client+Servers                    
Multicast    62638.19 ops/sec    0.31 ms    0.54 ms    4464 B/op         83 allocs/op    

Buffer size: 10
Benchmark    Througput            Latency    Std.dev    Client+Servers                    
Multicast    100948.09 ops/sec    0.50 ms    0.89 ms    4529 B/op         83 allocs/op    

Buffer size: 100
Benchmark    Througput            Latency    Std.dev    Client+Servers                    
Multicast    156563.76 ops/sec    1.67 ms    1.85 ms    4547 B/op         83 allocs/op    

Buffer size: 1000
Benchmark    Througput            Latency    Std.dev     Client+Servers                    
Multicast    153235.60 ops/sec    9.49 ms    17.98 ms    4652 B/op         83 allocs/op    
```

