### PR TITLE
Fix data race in orderedNodeStream

### DIFF
--- a/cmd/protoc-gen-gorums/gengorums/template_static.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_static.go
@@ -1007,7 +1007,7 @@ type orderedNodeStream struct {
 	gorumsClient ordering.GorumsClient
 	gorumsStream ordering.Gorums_NodeStreamClient
 	streamMut    sync.RWMutex
-	streamBroken bool
+	streamBroken uint32
 }
 
 func (s *orderedNodeStream) connectOrderedStream(ctx context.Context, conn *grpc.ClientConn) error {
@@ -1031,7 +1031,7 @@ func (s *orderedNodeStream) sendMsgs(ctx context.Context) {
 		case req = <-s.sendQ:
 		}
 		// return error if stream is broken
-		if s.streamBroken {
+		if atomic.LoadUint32(&s.streamBroken) == 1 {
 			err := status.Errorf(codes.Unavailable, "stream is down")
 			s.putResult(req.metadata.MessageID, &orderingResult{nid: s.node.ID(), reply: nil, err: err})
 			continue
@@ -1043,7 +1043,7 @@ func (s *orderedNodeStream) sendMsgs(ctx context.Context) {
 			s.streamMut.RUnlock()
 			continue
 		}
-		s.streamBroken = true
+		atomic.StoreUint32(&s.streamBroken, 1)
 		s.streamMut.RUnlock()
 		s.node.setLastErr(err)
 		// return the error
@@ -1057,7 +1057,7 @@ func (s *orderedNodeStream) recvMsgs(ctx context.Context) {
 		s.streamMut.RLock()
 		err := s.gorumsStream.RecvMsg(resp)
 		if err != nil {
-			s.streamBroken = true
+			atomic.StoreUint32(&s.streamBroken, 1)
 			s.streamMut.RUnlock()
 			s.node.setLastErr(err)
 			// attempt to reconnect
@@ -1085,7 +1085,7 @@ func (s *orderedNodeStream) reconnectStream(ctx context.Context) {
 		var err error
 		s.gorumsStream, err = s.gorumsClient.NodeStream(ctx)
 		if err == nil {
-			s.streamBroken = false
+			atomic.StoreUint32(&s.streamBroken, 0)
 			return
 		}
 		s.node.setLastErr(err)


### PR DESCRIPTION
`orderedNodeStream` had a data race when reconnecting. Specifically, a boolean named `streamBroken` was being read and written to at the same time. `streamBroken` is used to make the `sendMsgs` function return errors while the stream is reconnecting. This PR makes `streamBroken` a `uint32` and uses atomic load/store to access it. We cannot simply make the `streamMut` `RWMutex` into a regular `Mutex` to solve this, because then the `sendMsgs` and `receiveMsgs` functions would not be able to send/receive on the stream at the same time. The reason for the mutex is to make sure that the `reconnectStream` function has exclusive access to the stream while attempting to reconnect.

Fixes #94 