### PR TITLE
Compile test protos before running lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,18 +1,29 @@
 name: golangci-lint
-on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@master
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - uses: actions/checkout@v2
+      - name: Run Make
+        run: make
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ proto_path 				:= $(dev_path):third_party:.
 plugin_deps				:= gorums.pb.go internal/ordering/opts.pb.go internal/correctable/opts.pb.go $(static_file)
 benchmark_deps			:= benchmark/benchmark.pb.go benchmark/benchmark_grpc.pb.go benchmark/benchmark_gorums.pb.go
 
-.PHONY: dev tools bootstrapgorums installgorums benchmark test
+.PHONY: all dev tools bootstrapgorums installgorums benchmark test compiletests
+
+all: dev benchmark compiletests
 
 dev: installgorums ordering/ordering.pb.go ordering/ordering_grpc.pb.go
 	@rm -f $(dev_path)/zorums*.pb.go
@@ -48,6 +50,9 @@ bootstrapgorums: tools
 	@echo "Bootstrapping gorums plugin"
 	@go install github.com/relab/gorums/cmd/protoc-gen-gorums
 endif
+
+compiletests: installgorums
+	@$(MAKE) --no-print-directory -C ./tests all
 
 test: installgorums
 	@go test -v $(dev_path)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,11 @@
-.PHONY: runtests qf order message_encoding metadata tls reconnect
-
 # Tests that should be run each time
-runtests: ordering message_encoding metadata tls reconnect
+RUNTESTS := ordering message_encoding metadata tls reconnect
+
+.PHONY: all runtests qf order message_encoding metadata tls reconnect
+
+all: $(RUNTESTS)
+
+runtests: $(RUNTESTS)
 	@for package in $^; do \
 		go test -v ./$$package; \
 	done


### PR DESCRIPTION
The golangci-lint workflow needs to compile the test protos before running because the compiled test protos are no longer included in the repo. This PR adds the necessary steps to compile the test protos such that all required files are present before linting is done. I have decided against including the lint step within the test workflow because does not need to be run on different platforms. In addition, the test and lint workflows can run in parallel since they are separate.