### PR TITLE
Fixed warnings reported by golint

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -23,6 +23,7 @@ type Options struct {
 	Remote     bool          // Whether the servers are remote (true) or local (false)
 }
 
+// Bench is a Benchmark with a name and description
 type Bench struct {
 	Name        string
 	Description string
@@ -241,6 +242,7 @@ func runServerBenchmark(opts Options, cfg *Configuration, f serverFunc) (*Result
 	return resp, nil
 }
 
+// GetBenchmarks returns a list of Benchmarks that can be performed on the configuration
 func GetBenchmarks(cfg *Configuration) []Bench {
 	m := []Bench{
 		{

--- a/cmd/protoc-gen-gorums/dev/mgr.go
+++ b/cmd/protoc-gen-gorums/dev/mgr.go
@@ -66,7 +66,7 @@ func NewManager(opts ...ManagerOption) (*Manager, error) {
 	if m.opts.idMapping != nil {
 		for naddr, id := range m.opts.idMapping {
 			if m.lookup[id] != nil {
-				err := fmt.Errorf("two node ids are identical(id %d). Node ids has to be unique!", id)
+				err := fmt.Errorf("Two node ids are identical(id %d). Node ids have to be unique", id)
 				return nil, ManagerCreationError(err)
 			}
 			nodeAddrs = append(nodeAddrs, naddr)

--- a/cmd/protoc-gen-gorums/dev/server.go
+++ b/cmd/protoc-gen-gorums/dev/server.go
@@ -89,6 +89,7 @@ func WithServerBufferSize(size uint) ServerOption {
 	}
 }
 
+// WithGRPCServerOptions allows to set gRPC options for the server.
 func WithGRPCServerOptions(opts ...grpc.ServerOption) ServerOption {
 	return func(o *serverOptions) {
 		o.grpcOpts = append(o.grpcOpts, opts...)

--- a/cmd/protoc-gen-gorums/gengorums/template_static.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_static.go
@@ -353,7 +353,7 @@ func NewManager(opts ...ManagerOption) (*Manager, error) {
 	if m.opts.idMapping != nil {
 		for naddr, id := range m.opts.idMapping {
 			if m.lookup[id] != nil {
-				err := fmt.Errorf("two node ids are identical(id %d). Node ids has to be unique!", id)
+				err := fmt.Errorf("Two node ids are identical(id %d). Node ids have to be unique", id)
 				return nil, ManagerCreationError(err)
 			}
 			nodeAddrs = append(nodeAddrs, naddr)
@@ -1183,6 +1183,7 @@ func WithServerBufferSize(size uint) ServerOption {
 	}
 }
 
+// WithGRPCServerOptions allows to set gRPC options for the server.
 func WithGRPCServerOptions(opts ...grpc.ServerOption) ServerOption {
 	return func(o *serverOptions) {
 		o.grpcOpts = append(o.grpcOpts, opts...)

--- a/examples/storage/repl.go
+++ b/examples/storage/repl.go
@@ -89,6 +89,8 @@ func (r repl) ReadLine() (string, error) {
 	return r.term.ReadLine()
 }
 
+// Repl runs an interactive Read-eval-print loop, that allows users to run commands that perform
+// RPCs and quorum calls using the manager and configuration.
 func Repl(mgr *proto.Manager, defaultCfg *proto.Configuration) {
 	r := newRepl(mgr, defaultCfg)
 
@@ -193,7 +195,7 @@ func (r repl) qcCfg(args []string) {
 	}
 }
 
-func (_ repl) readRPC(args []string, node *proto.Node) {
+func (repl) readRPC(args []string, node *proto.Node) {
 	if len(args) < 1 {
 		fmt.Println("Read requires a key to read.")
 		return
@@ -212,7 +214,7 @@ func (_ repl) readRPC(args []string, node *proto.Node) {
 	fmt.Printf("%s = %s\n", args[0], resp.GetValue())
 }
 
-func (_ repl) writeRPC(args []string, node *proto.Node) {
+func (repl) writeRPC(args []string, node *proto.Node) {
 	if len(args) < 2 {
 		fmt.Println("Write requires a key and a value to write.")
 		return
@@ -231,7 +233,7 @@ func (_ repl) writeRPC(args []string, node *proto.Node) {
 	fmt.Println("Write OK")
 }
 
-func (_ repl) readQC(args []string, cfg *proto.Configuration) {
+func (repl) readQC(args []string, cfg *proto.Configuration) {
 	if len(args) < 1 {
 		fmt.Println("Read requires a key to read.")
 		return
@@ -250,7 +252,7 @@ func (_ repl) readQC(args []string, cfg *proto.Configuration) {
 	fmt.Printf("%s = %s\n", args[0], resp.GetValue())
 }
 
-func (_ repl) writeQC(args []string, cfg *proto.Configuration) {
+func (repl) writeQC(args []string, cfg *proto.Configuration) {
 	if len(args) < 2 {
 		fmt.Println("Write requires a key and a value to write.")
 		return

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 # Tests that should be run each time
-RUNTESTS := ordering message_encoding metadata tls reconnect
+RUNTESTS := ordering encoding metadata tls reconnect
 
-.PHONY: all runtests qf order message_encoding metadata tls reconnect
+.PHONY: all runtests qf order encoding metadata tls reconnect
 
 all: $(RUNTESTS)
 
@@ -14,7 +14,7 @@ qf: qf/qf.pb.go qf/qf_grpc.pb.go qf/qf_gorums.pb.go
 
 ordering: ordering/order.pb.go ordering/order_gorums.pb.go
 
-message_encoding: message_encoding/message_encoding.pb.go message_encoding/message_encoding_gorums.pb.go
+encoding: encoding/encoding.pb.go encoding/encoding_gorums.pb.go
 
 metadata: metadata/metadata.pb.go metadata/metadata_gorums.pb.go
 

--- a/tests/encoding/encoding.proto
+++ b/tests/encoding/encoding.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package message_encoding;
+package encoding;
 
-option go_package = "github.com/relab/gorums/tests/message_encoding";
+option go_package = "github.com/relab/gorums/tests/encoding";
 
 import "gorums.proto";
 

--- a/tests/encoding/encoding_test.go
+++ b/tests/encoding/encoding_test.go
@@ -1,4 +1,4 @@
-package message_encoding
+package encoding
 
 import (
 	"fmt"


### PR DESCRIPTION
This PR fixes some warnings reported by `golint`: https://goreportcard.com/report/github.com/relab/gorums#golint
* Added some missing comments to exported symbols
* Renamed tests/message_encoding to tests/encoding
* Other minor cleanups