### PR TITLE
Remove the `grpc.CallOption` field from ordered RPCs

### DIFF
--- a/cmd/protoc-gen-gorums/dev/zorums_ordered_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_ordered_gorums.pb.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 	ordering "github.com/relab/gorums/ordering"
 	trace "golang.org/x/net/trace"
-	grpc "google.golang.org/grpc"
 	time "time"
 )
 
@@ -335,7 +334,7 @@ func (c *Configuration) OrderingCombo(ctx context.Context, in *Request, f func(*
 }
 
 // OrderingUnaryRPC is testing that we can create ordered Unary RPCs
-func (n *Node) OrderingUnaryRPC(ctx context.Context, in *Request, opts ...grpc.CallOption) (resp *Response, err error) {
+func (n *Node) OrderingUnaryRPC(ctx context.Context, in *Request) (resp *Response, err error) {
 
 	// get the ID which will be used to return the correct responses for a request
 	msgID := n.nextMsgID()

--- a/cmd/protoc-gen-gorums/gengorums/template_ordered_qc.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_ordered_qc.go
@@ -5,6 +5,10 @@ var orderingVariables = `
 {{$unexportMethod := unexport .Method.GoName}}
 `
 
+var orderedRPCVariables = orderingVariables + `
+{{$context := use "context.Context" .GenFile}}
+`
+
 var orderedQCSignature = `func (c *Configuration) {{$method}}(` +
 	`ctx {{$context}}, in *{{$in}}` +
 	`{{perNodeFnType .GenFile .Method ", f"}})` +
@@ -85,8 +89,7 @@ var orderingReply = `
 `
 
 var orderingQC = commonVariables +
-	quorumCallVariables +
-	orderingVariables +
+	orderedRPCVariables +
 	quorumCallComment +
 	orderedQCSignature +
 	orderingPreamble +

--- a/cmd/protoc-gen-gorums/gengorums/template_ordered_rpc.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_ordered_rpc.go
@@ -3,8 +3,7 @@ package gengorums
 var orderingRPCComment = `{{.Method.Comments.Leading}}`
 
 var orderingRPCSignature = `func (n *Node) {{$method}}(` +
-	`ctx {{$context}}, in *{{$in}}, ` +
-	`opts ...{{$opts}})` +
+	`ctx {{$context}}, in *{{$in}}) ` +
 	`(resp *{{$out}}, err error) {
 `
 
@@ -42,8 +41,7 @@ var orderingRPCBody = `
 `
 
 var orderingRPC = commonVariables +
-	quorumCallVariables +
-	orderingVariables +
+	orderedRPCVariables +
 	orderingRPCComment +
 	orderingRPCSignature +
 	orderingRPCPreamble +

--- a/examples/storage/proto/storage_gorums.pb.go
+++ b/examples/storage/proto/storage_gorums.pb.go
@@ -327,7 +327,7 @@ func NewManager(opts ...ManagerOption) (*Manager, error) {
 	if m.opts.idMapping != nil {
 		for naddr, id := range m.opts.idMapping {
 			if m.lookup[id] != nil {
-				err := fmt.Errorf("two node ids are identical(id %d). Node ids has to be unique!", id)
+				err := fmt.Errorf("Two node ids are identical(id %d). Node ids have to be unique", id)
 				return nil, ManagerCreationError(err)
 			}
 			nodeAddrs = append(nodeAddrs, naddr)
@@ -981,7 +981,7 @@ type orderedNodeStream struct {
 	gorumsClient ordering.GorumsClient
 	gorumsStream ordering.Gorums_NodeStreamClient
 	streamMut    sync.RWMutex
-	streamBroken bool
+	streamBroken uint32
 }
 
 func (s *orderedNodeStream) connectOrderedStream(ctx context.Context, conn *grpc.ClientConn) error {
@@ -1005,7 +1005,7 @@ func (s *orderedNodeStream) sendMsgs(ctx context.Context) {
 		case req = <-s.sendQ:
 		}
 		// return error if stream is broken
-		if s.streamBroken {
+		if atomic.LoadUint32(&s.streamBroken) == 1 {
 			err := status.Errorf(codes.Unavailable, "stream is down")
 			s.putResult(req.metadata.MessageID, &orderingResult{nid: s.node.ID(), reply: nil, err: err})
 			continue
@@ -1017,7 +1017,7 @@ func (s *orderedNodeStream) sendMsgs(ctx context.Context) {
 			s.streamMut.RUnlock()
 			continue
 		}
-		s.streamBroken = true
+		atomic.StoreUint32(&s.streamBroken, 1)
 		s.streamMut.RUnlock()
 		s.node.setLastErr(err)
 		// return the error
@@ -1031,7 +1031,7 @@ func (s *orderedNodeStream) recvMsgs(ctx context.Context) {
 		s.streamMut.RLock()
 		err := s.gorumsStream.RecvMsg(resp)
 		if err != nil {
-			s.streamBroken = true
+			atomic.StoreUint32(&s.streamBroken, 1)
 			s.streamMut.RUnlock()
 			s.node.setLastErr(err)
 			// attempt to reconnect
@@ -1059,7 +1059,7 @@ func (s *orderedNodeStream) reconnectStream(ctx context.Context) {
 		var err error
 		s.gorumsStream, err = s.gorumsClient.NodeStream(ctx)
 		if err == nil {
-			s.streamBroken = false
+			atomic.StoreUint32(&s.streamBroken, 0)
 			return
 		}
 		s.node.setLastErr(err)
@@ -1157,6 +1157,7 @@ func WithServerBufferSize(size uint) ServerOption {
 	}
 }
 
+// WithGRPCServerOptions allows to set gRPC options for the server.
 func WithGRPCServerOptions(opts ...grpc.ServerOption) ServerOption {
 	return func(o *serverOptions) {
 		o.grpcOpts = append(o.grpcOpts, opts...)
@@ -1264,7 +1265,7 @@ func (n *Node) closeStream() (err error) {
 }
 
 // ReadRPC executes the Read RPC on a single Node
-func (n *Node) ReadRPC(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (resp *ReadResponse, err error) {
+func (n *Node) ReadRPC(ctx context.Context, in *ReadRequest) (resp *ReadResponse, err error) {
 
 	// get the ID which will be used to return the correct responses for a request
 	msgID := n.nextMsgID()
@@ -1296,7 +1297,7 @@ func (n *Node) ReadRPC(ctx context.Context, in *ReadRequest, opts ...grpc.CallOp
 }
 
 // WriteRPC executes the Write RPC on a single Node
-func (n *Node) WriteRPC(ctx context.Context, in *WriteRequest, opts ...grpc.CallOption) (resp *WriteResponse, err error) {
+func (n *Node) WriteRPC(ctx context.Context, in *WriteRequest) (resp *WriteResponse, err error) {
 
 	// get the ID which will be used to return the correct responses for a request
 	msgID := n.nextMsgID()


### PR DESCRIPTION
This PR removes the `opts ...grpc.CallOption` field from Ordered Unary RPCs. The field was not actually used for anything and I probably forgot to remove it after copying some code... The field is variadic, so it should not break any existing code as long as it did not attempt to use any call options (which would have no effect anyway).