### PR TITLE
Make TestSetup use type safe ServerIface

### DIFF
--- a/testing_gorums.go
+++ b/testing_gorums.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-type server interface {
+type ServerIface interface {
 	Serve(net.Listener) error
 	Stop()
 }
@@ -14,16 +14,12 @@ type server interface {
 // function, and returns the server addresses along with a stop function
 // that should be called to shut down the test.
 // This function can be used by other packages for testing purposes.
-func TestSetup(t testing.TB, numServers int, srvFunc func() interface{}) ([]string, func()) {
+func TestSetup(t testing.TB, numServers int, srvFn func() ServerIface) ([]string, func()) {
 	t.Helper()
-	servers := make([]server, numServers)
+	servers := make([]ServerIface, numServers)
 	addrs := make([]string, numServers)
 	for i := 0; i < numServers; i++ {
-		var srv server
-		var ok bool
-		if srv, ok = srvFunc().(server); !ok {
-			t.Fatal("Incompatible server type. You should use a GorumsServer or grpc.Server")
-		}
+		srv := srvFn()
 		// listen on any available port
 		lis, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {

--- a/tests/metadata/metadata_test.go
+++ b/tests/metadata/metadata_test.go
@@ -55,7 +55,7 @@ func initServer(t *testing.T) *gorums.Server {
 func TestMetadata(t *testing.T) {
 	want := uint32(1)
 
-	addrs, teardown := gorums.TestSetup(t, 1, func() interface{} { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	md := metadata.New(map[string]string{
@@ -84,7 +84,7 @@ func TestMetadata(t *testing.T) {
 }
 
 func TestPerNodeMetadata(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 2, func() interface{} { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 2, func() gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	perNodeMD := func(nid uint32) metadata.MD {
@@ -116,7 +116,7 @@ func TestPerNodeMetadata(t *testing.T) {
 }
 
 func TestCanGetPeerInfo(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 1, func() interface{} { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	mgr, err := NewManager(

--- a/tests/ordering/order_test.go
+++ b/tests/ordering/order_test.go
@@ -79,7 +79,7 @@ func (q testQSpec) AsyncHandlerQF(_ *Request, replies map[uint32]*Response) (*Re
 
 func setup(t *testing.T, cfgSize int) (cfg *Configuration, teardown func()) {
 	t.Helper()
-	addrs, closeServers := gorums.TestSetup(t, cfgSize, func() interface{} {
+	addrs, closeServers := gorums.TestSetup(t, cfgSize, func() gorums.ServerIface {
 		srv := gorums.NewServer()
 		RegisterGorumsTestServer(srv, &testSrv{})
 		return srv

--- a/tests/qf/qf_test.go
+++ b/tests/qf/qf_test.go
@@ -189,7 +189,7 @@ func (s testSrv) IgnoreReq(_ context.Context, req *Request, out func(*Response, 
 
 func BenchmarkFullStackQF(b *testing.B) {
 	for n := 3; n < 20; n += 2 {
-		_, stop := gorums.TestSetup(b, n, func() interface{} {
+		_, stop := gorums.TestSetup(b, n, func() gorums.ServerIface {
 			srv := gorums.NewServer()
 			RegisterQuorumFunctionServer(srv, &testSrv{})
 			return srv

--- a/tests/tls/tls_test.go
+++ b/tests/tls/tls_test.go
@@ -40,7 +40,7 @@ func TestTLS(t *testing.T) {
 		t.Errorf("Failed to parse cert: %v", err)
 	}
 
-	addrs, teardown := gorums.TestSetup(t, 1, func() interface{} {
+	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface {
 		srv := gorums.NewServer(gorums.WithGRPCServerOptions(grpc.Creds(credentials.NewServerTLSFromCert(&tlsCert))))
 		RegisterTLSServer(srv, &testSrv{})
 		return srv
@@ -48,8 +48,8 @@ func TestTLS(t *testing.T) {
 	defer teardown()
 
 	mgr, err := NewManager(
-		gorums.WithNodeList(addrs), 
-		gorums.WithDialTimeout(100*time.Millisecond), 
+		gorums.WithNodeList(addrs),
+		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithBlock(),
 			grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, "")),

--- a/tests/unresponsive/unreponsive_test.go
+++ b/tests/unresponsive/unreponsive_test.go
@@ -18,7 +18,7 @@ func (srv testSrv) TestUnresponsive(ctx context.Context, _ *Empty, _ func(*Empty
 
 // TestUnresponsive checks that the client is not blocked when the server is not receiving messages
 func TestUnresponsive(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 1, func() interface{} {
+	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface {
 		gorumsSrv := gorums.NewServer()
 		srv := &testSrv{}
 		RegisterUnresponsiveServer(gorumsSrv, srv)


### PR DESCRIPTION
This makes the TestSetup function take a type safe
function as argument instead of interface{}.
