### PR TITLE
Minor simplification of Configuration object

### DIFF
--- a/benchmark/benchmark_gorums.pb.go
+++ b/benchmark/benchmark_gorums.pb.go
@@ -18,7 +18,6 @@ import (
 type Configuration struct {
 	id    uint32
 	nodes []*gorums.Node
-	n     int
 	mgr   *Manager
 	qspec QuorumSpec
 	errs  chan gorums.Error
@@ -67,7 +66,7 @@ func (c *Configuration) Nodes() []*Node {
 
 // Size returns the number of nodes in the configuration.
 func (c *Configuration) Size() int {
-	return c.n
+	return len(c.nodes)
 }
 
 func (c *Configuration) String() string {
@@ -132,7 +131,6 @@ func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configurati
 
 	c := &Configuration{
 		nodes: nodes,
-		n:     len(nodes),
 		mgr:   m,
 		qspec: qspec,
 	}

--- a/cmd/protoc-gen-gorums/dev/config.go
+++ b/cmd/protoc-gen-gorums/dev/config.go
@@ -11,7 +11,6 @@ import (
 type Configuration struct {
 	id    uint32
 	nodes []*gorums.Node
-	n     int
 	mgr   *Manager
 	qspec QuorumSpec
 	errs  chan gorums.Error
@@ -60,7 +59,7 @@ func (c *Configuration) Nodes() []*Node {
 
 // Size returns the number of nodes in the configuration.
 func (c *Configuration) Size() int {
-	return c.n
+	return len(c.nodes)
 }
 
 func (c *Configuration) String() string {

--- a/cmd/protoc-gen-gorums/dev/mgr.go
+++ b/cmd/protoc-gen-gorums/dev/mgr.go
@@ -55,7 +55,6 @@ func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configurati
 
 	c := &Configuration{
 		nodes: nodes,
-		n:     len(nodes),
 		mgr:   m,
 		qspec: qspec,
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_static.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_static.go
@@ -28,7 +28,6 @@ var staticCode = `// A Configuration represents a static set of nodes on which q
 type Configuration struct {
 	id    uint32
 	nodes []*gorums.Node
-	n     int
 	mgr   *Manager
 	qspec QuorumSpec
 	errs  chan gorums.Error
@@ -77,7 +76,7 @@ func (c *Configuration) Nodes() []*Node {
 
 // Size returns the number of nodes in the configuration.
 func (c *Configuration) Size() int {
-	return c.n
+	return len(c.nodes)
 }
 
 func (c *Configuration) String() string {
@@ -142,7 +141,6 @@ func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configurati
 
 	c := &Configuration{
 		nodes: nodes,
-		n:     len(nodes),
 		mgr:   m,
 		qspec: qspec,
 	}


### PR DESCRIPTION
This PR aims to experiment with alternative arrangements of the Configuration and Manager objects.
The goal is to reduce the template_static.go further and to use interfaces to wire things up so that it becomes easier to maintain and test.

