### PR TITLE
Restructured receiveQueue API and fixed PerNode transformation functions

### DIFF
--- a/.vscode/gorums.txt
+++ b/.vscode/gorums.txt
@@ -54,6 +54,7 @@ quorumcall
 relab
 rlevel
 shlex
+srvs
 syncrq
 testprotos
 timestamppb

--- a/async.go
+++ b/async.go
@@ -37,10 +37,10 @@ func AsyncCall(ctx context.Context, d QuorumCallData) *Async {
 	for _, n := range d.Nodes {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
-			nodeArg := d.PerNodeArgFn(d.Message, n.id)
-			if nodeArg != nil {
+			msg = d.PerNodeArgFn(d.Message, n.id)
+			if !msg.ProtoReflect().IsValid() {
 				expectedReplies--
-				continue
+				continue // don't send if no msg
 			}
 		}
 		n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}}

--- a/async.go
+++ b/async.go
@@ -31,7 +31,8 @@ func (f *Async) Done() bool {
 
 func AsyncCall(ctx context.Context, d QuorumCallData) *Async {
 	expectedReplies := len(d.Nodes)
-	md, replyChan, callDone := d.Manager.newCall(d.Method, expectedReplies, true)
+	md := d.Manager.newCall(d.Method)
+	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 
 	for _, n := range d.Nodes {
 		msg := d.Message

--- a/callopts.go
+++ b/callopts.go
@@ -3,8 +3,8 @@ package gorums
 import "google.golang.org/protobuf/runtime/protoimpl"
 
 type callOptions struct {
-	callType  *protoimpl.ExtensionInfo
-	sendAsync bool
+	callType      *protoimpl.ExtensionInfo
+	noSendWaiting bool
 }
 
 // CallOption is a function that sets a value in the given callOptions struct
@@ -18,10 +18,10 @@ func getCallOptions(callType *protoimpl.ExtensionInfo, opts []CallOption) callOp
 	return o
 }
 
-// WithAsyncSend is a CallOption that makes Unicast or Multicast methods run asynchronously,
-// instead of blocking until the message is sent.
+// WithAsyncSend is a CallOption that makes Unicast or Multicast methods
+// return immediately instead of blocking until the message has been sent.
 func WithAsyncSend() CallOption {
 	return func(o *callOptions) {
-		o.sendAsync = true
+		o.noSendWaiting = true
 	}
 }

--- a/callopts.go
+++ b/callopts.go
@@ -18,9 +18,9 @@ func getCallOptions(callType *protoimpl.ExtensionInfo, opts []CallOption) callOp
 	return o
 }
 
-// WithAsyncSend is a CallOption that makes Unicast or Multicast methods
+// WithNoSendWaiting is a CallOption that makes Unicast or Multicast methods
 // return immediately instead of blocking until the message has been sent.
-func WithAsyncSend() CallOption {
+func WithNoSendWaiting() CallOption {
 	return func(o *callOptions) {
 		o.noSendWaiting = true
 	}

--- a/correctable.go
+++ b/correctable.go
@@ -90,10 +90,10 @@ func CorrectableCall(ctx context.Context, d CorrectableCallData) *Correctable {
 	for _, n := range d.Nodes {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
-			nodeArg := d.PerNodeArgFn(d.Message, n.id)
-			if nodeArg != nil {
+			msg = d.PerNodeArgFn(d.Message, n.id)
+			if !msg.ProtoReflect().IsValid() {
 				expectedReplies--
-				continue
+				continue // don't send if no msg
 			}
 		}
 		n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}}

--- a/correctable.go
+++ b/correctable.go
@@ -84,7 +84,8 @@ type CorrectableCallData struct {
 
 func CorrectableCall(ctx context.Context, d CorrectableCallData) *Correctable {
 	expectedReplies := len(d.Nodes)
-	md, replyChan, callDone := d.Manager.newCall(d.Method, expectedReplies, true)
+	md := d.Manager.newCall(d.Method)
+	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 
 	for _, n := range d.Nodes {
 		msg := d.Message

--- a/mgr_test.go
+++ b/mgr_test.go
@@ -89,7 +89,7 @@ func (_ dummySrv) Test(ctx context.Context, _ *dummy.Empty, _ func(*dummy.Empty,
 }
 
 func TestManagerAddNodeWithConn(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 3, func() gorums.ServerIface {
+	addrs, teardown := gorums.TestSetup(t, 3, func(_ int) gorums.ServerIface {
 		srv := gorums.NewServer()
 		dummy.RegisterDummyServer(srv, &dummySrv{})
 		return srv

--- a/mgr_test.go
+++ b/mgr_test.go
@@ -88,7 +88,6 @@ func TestManagerLogging(t *testing.T) {
 }
 
 func TestManagerAddNode(t *testing.T) {
-	nodeMap := map[string]uint32{"127.0.0.1:9080": 1, "127.0.0.1:9081": 2, "127.0.0.1:9082": 3, "127.0.0.1:9083": 4}
 	mgr, err := gorums.NewManager(gorums.WithNodeMap(nodeMap), gorums.WithNoConnect())
 	if err != nil {
 		t.Fatalf("NewManager(): unexpected error: %s", err)
@@ -104,9 +103,13 @@ func TestManagerAddNode(t *testing.T) {
 		{"127.0.1.1:1234", 2, "node ID 2 already exists (127.0.1.1:1234)"},
 	}
 	for _, test := range tests {
-		err = mgr.AddNode(test.addr, test.id)
+		node, err := gorums.NewNodeWithID(test.addr, test.id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = mgr.AddNode(node)
 		if err != nil && err.Error() != test.err {
-			t.Errorf("mgr.AddNode(%s, %d) = %s, expected %s", test.addr, test.id, err.Error(), test.err)
+			t.Errorf("mgr.AddNode(Node(%s, %d)) = %s, expected %s", test.addr, test.id, err.Error(), test.err)
 		}
 	}
 }
@@ -136,9 +139,13 @@ func TestManagerAddNodeWithConn(t *testing.T) {
 		t.Errorf("mgr.Size() = %d, expected %d", mgr.Size(), len(addrs)-1)
 	}
 
-	err = mgr.AddNode(addrs[2], 0)
+	node, err := gorums.NewNode(addrs[2])
 	if err != nil {
-		t.Errorf("mgr.AddNode(%s, %d) = %q, expected %q", addrs[2], 0, err.Error(), "")
+		t.Fatal(err)
+	}
+	err = mgr.AddNode(node)
+	if err != nil {
+		t.Errorf("mgr.AddNode(%s) = %q, expected %q", addrs[2], err.Error(), "")
 	}
 	if mgr.Size() != len(addrs) {
 		t.Errorf("mgr.Size() = %d, expected %d", mgr.Size(), len(addrs))

--- a/multicast.go
+++ b/multicast.go
@@ -23,8 +23,7 @@ func Multicast(ctx context.Context, d QuorumCallData, opts ...CallOption) {
 		n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}, opts: o}
 	}
 
-	// TODO rename sendAsync to waitSend or waitSendCompletion
-	if o.sendAsync {
+	if o.noSendWaiting {
 		// don't wait for messages to be sent
 		return
 	}

--- a/multicast.go
+++ b/multicast.go
@@ -6,29 +6,35 @@ import (
 
 // Multicast is a one-way call; no replies are processed.
 // By default this function returns once the message has been sent to all nodes.
-// Providing the call option WithAsyncSend, the function may return
+// Providing the call option WithNoSendWaiting, the function may return
 // before the message has been sent.
 func Multicast(ctx context.Context, d QuorumCallData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
 
 	md := d.Manager.newCall(d.Method)
-	for _, n := range d.Nodes {
-		msg := d.Message
-		if d.PerNodeArgFn != nil {
-			nodeArg := d.PerNodeArgFn(d.Message, n.id)
-			if nodeArg != nil {
-				continue
+	send := func() {
+		for _, n := range d.Nodes {
+			msg := d.Message
+			if d.PerNodeArgFn != nil {
+				nodeArg := d.PerNodeArgFn(d.Message, n.id)
+				if nodeArg != nil {
+					continue
+				}
 			}
+			n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}, opts: o}
 		}
-		n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}, opts: o}
 	}
 
 	if o.noSendWaiting {
-		// don't wait for messages to be sent
-		return
+		send()
+		return // don't wait for messages to be sent
 	}
+
 	replyChan, callDone := d.Manager.newReply(md, len(d.Nodes))
-	// wait until the messages have been sent (nodeStream sends empty replies when this happens)
+	send()
+
+	// nodeStream sends an empty reply on replyChan when the message has been sent
+	// wait until the message has been sent
 	for range d.Nodes {
 		<-replyChan
 	}

--- a/node.go
+++ b/node.go
@@ -31,16 +31,26 @@ type Node struct {
 	*orderedNodeStream
 }
 
-// NewNode returns a new node for the provided address and id.
-func NewNode(addr string, id uint32) (*Node, error) {
+// NewNode returns a new node for the provided address.
+func NewNode(addr string) (*Node, error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("node error: '%s' error: %v", addr, err)
 	}
-	if id == 0 {
-		h := fnv.New32a()
-		_, _ = h.Write([]byte(tcpAddr.String()))
-		id = h.Sum32()
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(tcpAddr.String()))
+	return &Node{
+		id:      h.Sum32(),
+		addr:    tcpAddr.String(),
+		latency: -1 * time.Second,
+	}, nil
+}
+
+// NewNodeWithID returns a new node for the provided address and id.
+func NewNodeWithID(addr string, id uint32) (*Node, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("node error: '%s' error: %v", addr, err)
 	}
 	return &Node{
 		id:      id,

--- a/ordering.go
+++ b/ordering.go
@@ -113,9 +113,9 @@ func (s *orderedNodeStream) connectOrderedStream(ctx context.Context, conn *grpc
 }
 
 func (s *orderedNodeStream) sendMsg(req gorumsStreamRequest) (err error) {
-	// unblock the waiting caller when sendAsync is not enabled
+	// unblock the waiting caller unless noSendWaiting is enabled
 	defer func() {
-		if req.opts.callType == E_Multicast || req.opts.callType == E_Unicast && !req.opts.sendAsync {
+		if req.opts.callType == E_Multicast || req.opts.callType == E_Unicast && !req.opts.noSendWaiting {
 			s.putResult(req.msg.Metadata.MessageID, &gorumsStreamResult{})
 		}
 	}()

--- a/ordering_test.go
+++ b/ordering_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/relab/gorums/ordering"
 )
 
 // BenchmarkReceiveQueue is here to benchmark whether or not the receiveQueue
@@ -24,6 +26,13 @@ import (
 // BenchmarkReceiveQueue/syncMapStruct-24   	 1281080	       929 ns/op	     464 B/op	      10 allocs/op
 // BenchmarkReceiveQueue/syncMapDirect-24   	 1293362	       929 ns/op	     464 B/op	      10 allocs/op
 //
+// After splitting newCall into newCall and newReply, we get these results:
+// % go test -v -benchmem -run none -bench BenchmarkReceiveQueue
+// BenchmarkReceiveQueue/NewCall-24         	 3108373	       372 ns/op	     240 B/op	       4 allocs/op
+// BenchmarkReceiveQueue/RWMutexMap-24      	 4714849	       254 ns/op	     128 B/op	       2 allocs/op
+// BenchmarkReceiveQueue/syncMapStruct-24   	 1326286	       909 ns/op	     464 B/op	      10 allocs/op
+// BenchmarkReceiveQueue/syncMapDirect-24   	 1326224	       909 ns/op	     464 B/op	      10 allocs/op
+//
 // Note that NewCall is expected to require more allocations than RWMutexMap
 // because it allocates Metadata and the delete function, and will be a bit slower
 // for these reasons. However, when used in QuorumCall, which also has to allocate
@@ -40,7 +49,7 @@ import (
 // QuorumCall    1041.38 ops/sec    0.96 ms    0.35 ms    19893 B/op        535 allocs/op
 //
 // After replacing the receiveQueue methods with NewCall:
-
+//
 // cmd/benchmark/benchmark -config-size 9 -quorum-size 5 -time 5s -benchmarks ^QuorumCall
 // Benchmark     Throughput         Latency    Std.dev    Client+Servers
 // QuorumCall    1044.11 ops/sec    0.96 ms    0.36 ms    19928 B/op        536 allocs/op
@@ -48,6 +57,16 @@ import (
 // QuorumCall    1038.68 ops/sec    0.96 ms    0.36 ms    19914 B/op        535 allocs/op
 // QuorumCall    1038.28 ops/sec    0.96 ms    0.36 ms    19954 B/op        536 allocs/op
 // QuorumCall    1046.57 ops/sec    0.95 ms    0.39 ms    19955 B/op        536 allocs/op
+//
+// After replacing the single newCall with newCall and newReply:
+//
+// cmd/benchmark/benchmark -config-size 9 -quorum-size 5 -time 5s -benchmarks ^QuorumCall
+// Benchmark     Throughput         Latency    Std.dev    Client+Servers
+// QuorumCall    1033.38 ops/sec    0.97 ms    0.37 ms    19965 B/op        536 allocs/op
+// QuorumCall    1026.32 ops/sec    0.97 ms    0.38 ms    19919 B/op        535 allocs/op
+// QuorumCall    1037.70 ops/sec    0.96 ms    0.37 ms    19916 B/op        535 allocs/op
+// QuorumCall    1020.35 ops/sec    0.98 ms    0.38 ms    19927 B/op        535 allocs/op
+// QuorumCall    1028.64 ops/sec    0.97 ms    0.37 ms    19928 B/op        535 allocs/op
 //
 func BenchmarkReceiveQueue(b *testing.B) {
 	const (
@@ -59,7 +78,15 @@ func BenchmarkReceiveQueue(b *testing.B) {
 	result := &gorumsStreamResult{nid: 2, reply: nil, err: nil}
 	b.Run("NewCall", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			md, _, f := rq.newCall(methodName, numNodes, true)
+			md := rq.newCall(methodName)
+			_, f := rq.newReply(md, numNodes)
+			rq.putResult2(md.MessageID, result)
+			f()
+		}
+	})
+	b.Run("OldNewCall", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			md, _, f := rq.oldNewCall(methodName, numNodes, true)
 			rq.putResult2(md.MessageID, result)
 			f()
 		}
@@ -98,6 +125,29 @@ func BenchmarkReceiveQueue(b *testing.B) {
 			syncrq.Delete(msgID)
 		}
 	})
+}
+
+// newCall returns metadata for the call, a channel for receiving replies
+// and a done function to be called for clean up.
+// Only if reply is true will replyChan and the done function be allocated.
+func (m *receiveQueue) oldNewCall(method string, maxReplies int, reply bool) (md *ordering.Metadata, replyChan chan *gorumsStreamResult, done func()) {
+	msgID := atomic.AddUint64(&m.msgID, 1)
+	md = &ordering.Metadata{
+		MessageID: msgID,
+		Method:    method,
+	}
+	if reply {
+		replyChan = make(chan *gorumsStreamResult, maxReplies)
+		m.recvQMut.Lock()
+		m.recvQ[msgID] = replyChan
+		m.recvQMut.Unlock()
+		done = func() {
+			m.recvQMut.Lock()
+			delete(m.recvQ, msgID)
+			m.recvQMut.Unlock()
+		}
+	}
+	return
 }
 
 // nextMsgID is only used except for benchmarking.

--- a/quorumcall.go
+++ b/quorumcall.go
@@ -20,7 +20,8 @@ type QuorumCallData struct {
 
 func QuorumCall(ctx context.Context, d QuorumCallData) (resp protoreflect.ProtoMessage, err error) {
 	expectedReplies := len(d.Nodes)
-	md, replyChan, callDone := d.Manager.newCall(d.Method, expectedReplies, true)
+	md := d.Manager.newCall(d.Method)
+	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 	defer callDone()
 
 	for _, n := range d.Nodes {

--- a/quorumcall.go
+++ b/quorumcall.go
@@ -27,10 +27,10 @@ func QuorumCall(ctx context.Context, d QuorumCallData) (resp protoreflect.ProtoM
 	for _, n := range d.Nodes {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
-			nodeArg := d.PerNodeArgFn(d.Message, n.id)
-			if nodeArg != nil {
+			msg = d.PerNodeArgFn(d.Message, n.id)
+			if !msg.ProtoReflect().IsValid() {
 				expectedReplies--
-				continue
+				continue // don't send if no msg
 			}
 		}
 		n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: msg}}

--- a/rpc.go
+++ b/rpc.go
@@ -13,7 +13,8 @@ type CallData struct {
 }
 
 func RPCCall(ctx context.Context, d CallData) (resp protoreflect.ProtoMessage, err error) {
-	md, replyChan, callDone := d.Node.newCall(d.Method, 1, true)
+	md := d.Node.newCall(d.Method)
+	replyChan, callDone := d.Node.newReply(md, 1)
 	defer callDone()
 
 	d.Node.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}}

--- a/testing_gorums.go
+++ b/testing_gorums.go
@@ -14,12 +14,12 @@ type ServerIface interface {
 // function, and returns the server addresses along with a stop function
 // that should be called to shut down the test.
 // This function can be used by other packages for testing purposes.
-func TestSetup(t testing.TB, numServers int, srvFn func() ServerIface) ([]string, func()) {
+func TestSetup(t testing.TB, numServers int, srvFn func(i int) ServerIface) ([]string, func()) {
 	t.Helper()
 	servers := make([]ServerIface, numServers)
 	addrs := make([]string, numServers)
 	for i := 0; i < numServers; i++ {
-		srv := srvFn()
+		srv := srvFn(i)
 		// listen on any available port
 		lis, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 # Tests that should be run each time
-RUNTESTS := qf ordering metadata tls unresponsive dummy
+RUNTESTS := qf ordering metadata tls unresponsive dummy oneway
 
-.PHONY: all qf ordering metadata tls unresponsive dummy
+.PHONY: all qf ordering metadata tls unresponsive dummy oneway
 
 all: $(RUNTESTS)
 
@@ -16,6 +16,8 @@ tls: tls/tls.pb.go tls/tls_gorums.pb.go
 unresponsive: unresponsive/unresponsive.pb.go unresponsive/unresponsive_gorums.pb.go
 
 dummy: dummy/dummy.pb.go dummy/dummy_gorums.pb.go
+
+oneway: oneway/oneway.pb.go oneway/oneway_gorums.pb.go
 
 %.pb.go : %.proto
 	@protoc -I=..:. --go_out=paths=source_relative:. $<

--- a/tests/metadata/metadata_test.go
+++ b/tests/metadata/metadata_test.go
@@ -55,7 +55,7 @@ func initServer(t *testing.T) *gorums.Server {
 func TestMetadata(t *testing.T) {
 	want := uint32(1)
 
-	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	md := metadata.New(map[string]string{
@@ -84,7 +84,7 @@ func TestMetadata(t *testing.T) {
 }
 
 func TestPerNodeMetadata(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 2, func() gorums.ServerIface { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 2, func(_ int) gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	perNodeMD := func(nid uint32) metadata.MD {
@@ -116,7 +116,7 @@ func TestPerNodeMetadata(t *testing.T) {
 }
 
 func TestCanGetPeerInfo(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface { return initServer(t) })
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface { return initServer(t) })
 	defer teardown()
 
 	mgr, err := NewManager(

--- a/tests/oneway/oneway.proto
+++ b/tests/oneway/oneway.proto
@@ -5,9 +5,19 @@ option go_package = "github.com/relab/gorums/tests/oneway";
 import "gorums.proto";
 
 service OnewayTest {
-  rpc Unicast(Request) returns (Empty) { option (gorums.unicast) = true; }
-  rpc Multicast(Request) returns (Empty) { option (gorums.multicast) = true; }
+  rpc Unicast(Request) returns (Empty) {
+    option (gorums.unicast) = true;
+  }
+  rpc Multicast(Request) returns (Empty) {
+    option (gorums.multicast) = true;
+  }
+  rpc MulticastPerNode(Request) returns (Empty) {
+    option (gorums.multicast) = true;
+    option (gorums.per_node_arg) = true;
+  }
 }
 
-message Request { uint64 Num = 1; }
+message Request {
+  uint64 Num = 1;
+}
 message Empty {}

--- a/tests/oneway/oneway.proto
+++ b/tests/oneway/oneway.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package oneway;
+option go_package = "github.com/relab/gorums/tests/oneway";
+
+import "gorums.proto";
+
+service OnewayTest {
+  rpc Unicast(Request) returns (Empty) { option (gorums.unicast) = true; }
+  rpc Multicast(Request) returns (Empty) { option (gorums.multicast) = true; }
+}
+
+message Request { uint64 Num = 1; }
+message Empty {}

--- a/tests/oneway/oneway_test.go
+++ b/tests/oneway/oneway_test.go
@@ -1,0 +1,120 @@
+package oneway_test
+
+import (
+	context "context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/relab/gorums"
+	"github.com/relab/gorums/tests/oneway"
+	"google.golang.org/grpc"
+)
+
+type onewaySrv struct {
+	wg       sync.WaitGroup
+	received chan *oneway.Request
+}
+
+func (s *onewaySrv) Unicast(ctx context.Context, r *oneway.Request) {
+	s.received <- r
+	s.wg.Done()
+}
+
+func (s *onewaySrv) Multicast(ctx context.Context, r *oneway.Request) {
+	s.received <- r
+	s.wg.Done()
+}
+
+type testQSpec struct{}
+
+func setup(t *testing.T, cfgSize int) (cfg *oneway.Configuration, srvs []*onewaySrv, teardown func()) {
+	t.Helper()
+	srvs = make([]*onewaySrv, cfgSize)
+	for i := 0; i < cfgSize; i++ {
+		srvs[i] = &onewaySrv{received: make(chan *oneway.Request, numCalls)}
+	}
+
+	addrs, closeServers := gorums.TestSetup(t, cfgSize, func(i int) gorums.ServerIface {
+		srv := gorums.NewServer()
+		oneway.RegisterOnewayTestServer(srv, srvs[i])
+		return srv
+	})
+	mgr, err := oneway.NewManager(
+		gorums.WithNodeList(addrs),
+		gorums.WithDialTimeout(100*time.Millisecond),
+		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = mgr.NewConfiguration(mgr.NodeIDs(), &testQSpec{})
+	if err != nil {
+		t.Fatalf("Failed to create configuration: %v", err)
+	}
+	teardown = func() {
+		mgr.Close()
+		closeServers()
+	}
+	return cfg, srvs, teardown
+}
+
+const numCalls = 50
+
+func TestOnewayCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		calls    int
+		servers  int
+		sendWait bool
+	}{
+		{name: "UnicastSendWaiting____", calls: numCalls, servers: 1, sendWait: true},
+		{name: "UnicastNoSendWaiting__", calls: numCalls, servers: 1, sendWait: false},
+		{name: "MulticastSendWaiting__", calls: numCalls, servers: 1, sendWait: true},
+		{name: "MulticastNoSendWaiting", calls: numCalls, servers: 1, sendWait: false},
+		{name: "MulticastSendWaiting__", calls: numCalls, servers: 3, sendWait: true},
+		{name: "MulticastNoSendWaiting", calls: numCalls, servers: 3, sendWait: false},
+		{name: "MulticastSendWaiting__", calls: numCalls, servers: 9, sendWait: true},
+		{name: "MulticastNoSendWaiting", calls: numCalls, servers: 9, sendWait: false},
+	}
+
+	f := func(c *oneway.Configuration) func(context.Context, *oneway.Request, ...gorums.CallOption) {
+		if c.Size() == 1 {
+			return c.Nodes()[0].Unicast
+		}
+		return c.Multicast
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s/%d", test.name, test.servers), func(t *testing.T) {
+			cfg, srvs, teardown := setup(t, test.servers)
+			for i := 0; i < len(srvs); i++ {
+				srvs[i].wg.Add(test.calls)
+			}
+
+			for c := 1; c <= test.calls; c++ {
+				in := &oneway.Request{Num: uint64(c)}
+				if test.sendWait {
+					f(cfg)(context.Background(), in)
+				} else {
+					f(cfg)(context.Background(), in, gorums.WithNoSendWaiting())
+				}
+			}
+
+			// Check that each server received expected oneway messages
+			for i := 0; i < len(srvs); i++ {
+				srvs[i].wg.Wait()
+				close(srvs[i].received)
+				expected := uint64(1)
+				for r := range srvs[i].received {
+					if expected != r.Num {
+						t.Errorf("%s(%d) = %d, expected %d", test.name, expected, r.Num, expected)
+					}
+					expected++
+				}
+			}
+			teardown()
+		})
+	}
+}

--- a/tests/ordering/order_test.go
+++ b/tests/ordering/order_test.go
@@ -79,7 +79,7 @@ func (q testQSpec) AsyncHandlerQF(_ *Request, replies map[uint32]*Response) (*Re
 
 func setup(t *testing.T, cfgSize int) (cfg *Configuration, teardown func()) {
 	t.Helper()
-	addrs, closeServers := gorums.TestSetup(t, cfgSize, func() gorums.ServerIface {
+	addrs, closeServers := gorums.TestSetup(t, cfgSize, func(_ int) gorums.ServerIface {
 		srv := gorums.NewServer()
 		RegisterGorumsTestServer(srv, &testSrv{})
 		return srv

--- a/tests/qf/qf_test.go
+++ b/tests/qf/qf_test.go
@@ -189,7 +189,7 @@ func (s testSrv) IgnoreReq(_ context.Context, req *Request, out func(*Response, 
 
 func BenchmarkFullStackQF(b *testing.B) {
 	for n := 3; n < 20; n += 2 {
-		_, stop := gorums.TestSetup(b, n, func() gorums.ServerIface {
+		_, stop := gorums.TestSetup(b, n, func(_ int) gorums.ServerIface {
 			srv := gorums.NewServer()
 			RegisterQuorumFunctionServer(srv, &testSrv{})
 			return srv

--- a/tests/tls/tls_test.go
+++ b/tests/tls/tls_test.go
@@ -40,7 +40,7 @@ func TestTLS(t *testing.T) {
 		t.Errorf("Failed to parse cert: %v", err)
 	}
 
-	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface {
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
 		srv := gorums.NewServer(gorums.WithGRPCServerOptions(grpc.Creds(credentials.NewServerTLSFromCert(&tlsCert))))
 		RegisterTLSServer(srv, &testSrv{})
 		return srv

--- a/tests/unresponsive/unreponsive_test.go
+++ b/tests/unresponsive/unreponsive_test.go
@@ -18,7 +18,7 @@ func (srv testSrv) TestUnresponsive(ctx context.Context, _ *Empty, _ func(*Empty
 
 // TestUnresponsive checks that the client is not blocked when the server is not receiving messages
 func TestUnresponsive(t *testing.T) {
-	addrs, teardown := gorums.TestSetup(t, 1, func() gorums.ServerIface {
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
 		gorumsSrv := gorums.NewServer()
 		srv := &testSrv{}
 		RegisterUnresponsiveServer(gorumsSrv, srv)

--- a/unicast.go
+++ b/unicast.go
@@ -14,7 +14,7 @@ func Unicast(ctx context.Context, d CallData, opts ...CallOption) {
 	md := d.Node.newCall(d.Method)
 	d.Node.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
-	if o.sendAsync {
+	if o.noSendWaiting {
 		// don't wait for message to be sent
 		return
 	}

--- a/unicast.go
+++ b/unicast.go
@@ -10,14 +10,15 @@ import (
 // before the message has been sent.
 func Unicast(ctx context.Context, d CallData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
-	// sendAsync == true => replyChan and callDone are nil and thus cannot be used
-	md, replyChan, callDone := d.Node.newCall(d.Method, 1, !o.sendAsync)
+
+	md := d.Node.newCall(d.Method)
 	d.Node.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	if o.sendAsync {
 		// don't wait for message to be sent
 		return
 	}
+	replyChan, callDone := d.Node.newReply(md, 1)
 	// wait until the message has been sent (nodeStream sends an empty reply when this happens)
 	<-replyChan
 	callDone()

--- a/unicast.go
+++ b/unicast.go
@@ -6,20 +6,24 @@ import (
 
 // Unicast is a one-way call; no replies are processed.
 // By default this function returns once the message has been sent.
-// Providing the call option WithAsyncSend, the function may return
+// Providing the call option WithNoSendWaiting, the function may return
 // before the message has been sent.
 func Unicast(ctx context.Context, d CallData, opts ...CallOption) {
-	o := getCallOptions(E_Multicast, opts)
+	o := getCallOptions(E_Unicast, opts)
 
 	md := d.Node.newCall(d.Method)
-	d.Node.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
+	req := gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	if o.noSendWaiting {
-		// don't wait for message to be sent
-		return
+		d.Node.sendQ <- req
+		return // don't wait for message to be sent
 	}
+
+	// newReply must be called before adding req to sendQ
 	replyChan, callDone := d.Node.newReply(md, 1)
-	// wait until the message has been sent (nodeStream sends an empty reply when this happens)
+	d.Node.sendQ <- req
+	// nodeStream sends an empty reply on replyChan when the message has been sent
+	// wait until the message has been sent
 	<-replyChan
 	callDone()
 }

--- a/unicast_test.go
+++ b/unicast_test.go
@@ -21,7 +21,7 @@ func BenchmarkUnicast(b *testing.B) {
 	})
 	b.Run("UnicastAsyncSend/NewCall", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			unicastNewCall(context.Background(), cd, WithAsyncSend())
+			unicastNewCall(context.Background(), cd, WithNoSendWaiting())
 		}
 	})
 	b.Run("UnicastSyncSend/Basic", func(b *testing.B) {
@@ -31,7 +31,7 @@ func BenchmarkUnicast(b *testing.B) {
 	})
 	b.Run("UnicastAsyncSend/Basic", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			unicastBasic(context.Background(), cd, WithAsyncSend())
+			unicastBasic(context.Background(), cd, WithNoSendWaiting())
 		}
 	})
 }
@@ -43,7 +43,7 @@ func TestUnicast(t *testing.T) {
 	}
 	go consumeAndPutResult(cd.rq, cd.sendQ)
 	unicastBasic(context.Background(), cd)
-	unicastBasic(context.Background(), cd, WithAsyncSend())
+	unicastBasic(context.Background(), cd, WithNoSendWaiting())
 }
 
 type callData struct {

--- a/unicast_test.go
+++ b/unicast_test.go
@@ -64,7 +64,7 @@ func unicastBasic(ctx context.Context, d callData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
 	msgID := d.rq.nextMsgID()
 	var replyChan chan *gorumsStreamResult
-	if !o.sendAsync {
+	if !o.noSendWaiting {
 		replyChan = make(chan *gorumsStreamResult, 1)
 		d.rq.putChan(msgID, replyChan)
 		defer d.rq.deleteChan(msgID)
@@ -76,7 +76,7 @@ func unicastBasic(ctx context.Context, d callData, opts ...CallOption) {
 	d.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	// wait until the message has been sent (nodeStream will give an empty reply when this happens)
-	if !o.sendAsync {
+	if !o.noSendWaiting {
 		<-replyChan
 	}
 }
@@ -89,7 +89,7 @@ func unicastNewCall(ctx context.Context, d callData, opts ...CallOption) {
 	d.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	// wait until the message has been sent (nodeStream will give an empty reply when this happens)
-	if !o.sendAsync {
+	if !o.noSendWaiting {
 		<-replyChan
 		callDone()
 	}

--- a/unicast_test.go
+++ b/unicast_test.go
@@ -83,7 +83,9 @@ func unicastBasic(ctx context.Context, d callData, opts ...CallOption) {
 
 func unicastNewCall(ctx context.Context, d callData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
-	md, replyChan, callDone := d.rq.newCall(d.Method, 1, !o.sendAsync)
+	md := d.rq.newCall(d.Method)
+	replyChan, callDone := d.rq.newReply(md, 1)
+
 	d.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	// wait until the message has been sent (nodeStream will give an empty reply when this happens)


### PR DESCRIPTION
- Simplified call metadata and reply handling
- Renamed sendAsync call option to noSendWaiting
- Renamed WithAsyncSend() to WithNoSendWaiting()
- Adjusted gorums.TestSetup; use srvFn with srv index
- Add oneway test for unicast and multicast
- Fixed deadlock bugs in Unicast and Multicast
- Improved error checking for NewManager
- Fixed bug in node creation when id was zero
- Fixed bugs in PerNode transform func and added tests
