### PR TITLE
Implement call types on Configuration and Node

### DIFF
--- a/async.go
+++ b/async.go
@@ -29,12 +29,12 @@ func (f *Async) Done() bool {
 	}
 }
 
-func AsyncCall(ctx context.Context, d QuorumCallData) *Async {
-	expectedReplies := len(d.Nodes)
+func (c Configuration) AsyncCall(ctx context.Context, d QuorumCallData) *Async {
+	expectedReplies := len(c)
 	md := d.Manager.newCall(d.Method)
 	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 
-	for _, n := range d.Nodes {
+	for _, n := range c {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
 			msg = d.PerNodeArgFn(d.Message, n.id)

--- a/async.go
+++ b/async.go
@@ -31,8 +31,8 @@ func (f *Async) Done() bool {
 
 func (c Configuration) AsyncCall(ctx context.Context, d QuorumCallData) *Async {
 	expectedReplies := len(c)
-	md := d.Manager.newCall(d.Method)
-	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
+	md := c.newCall(d.Method)
+	replyChan, callDone := c.newReply(md, expectedReplies)
 
 	for _, n := range c {
 		msg := d.Message

--- a/benchmark/benchmark_gorums.pb.go
+++ b/benchmark/benchmark_gorums.pb.go
@@ -97,7 +97,6 @@ type Node struct {
 // reply and error when available.
 func (c *Configuration) AsyncQuorumCall(ctx context.Context, in *Echo) *AsyncEcho {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.AsyncQuorumCall",
 	}
@@ -119,9 +118,7 @@ var _ emptypb.Empty
 // Multicast is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) Multicast(ctx context.Context, in *TimedMsg, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.Multicast",
 	}
@@ -185,9 +182,7 @@ type QuorumSpec interface {
 // StartServerBenchmark is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) StartServerBenchmark(ctx context.Context, in *StartRequest) (resp *StartResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.StartServerBenchmark",
 	}
@@ -209,9 +204,7 @@ func (c *Configuration) StartServerBenchmark(ctx context.Context, in *StartReque
 // StopServerBenchmark is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) StopServerBenchmark(ctx context.Context, in *StopRequest) (resp *Result, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.StopServerBenchmark",
 	}
@@ -233,9 +226,7 @@ func (c *Configuration) StopServerBenchmark(ctx context.Context, in *StopRequest
 // StartBenchmark is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) StartBenchmark(ctx context.Context, in *StartRequest) (resp *StartResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.StartBenchmark",
 	}
@@ -257,9 +248,7 @@ func (c *Configuration) StartBenchmark(ctx context.Context, in *StartRequest) (r
 // StopBenchmark is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) StopBenchmark(ctx context.Context, in *StopRequest) (resp *MemoryStatList, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.StopBenchmark",
 	}
@@ -280,9 +269,7 @@ func (c *Configuration) StopBenchmark(ctx context.Context, in *StopRequest) (res
 
 // benchmarks
 func (c *Configuration) QuorumCall(ctx context.Context, in *Echo) (resp *Echo, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.QuorumCall",
 	}
@@ -304,9 +291,7 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Echo) (resp *Echo, e
 // SlowServer is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) SlowServer(ctx context.Context, in *Echo) (resp *Echo, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "benchmark.Benchmark.SlowServer",
 	}

--- a/benchmark/benchmark_gorums.pb.go
+++ b/benchmark/benchmark_gorums.pb.go
@@ -98,7 +98,6 @@ type Node struct {
 func (c *Configuration) AsyncQuorumCall(ctx context.Context, in *Echo) *AsyncEcho {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.AsyncQuorumCall",
 	}
@@ -110,7 +109,7 @@ func (c *Configuration) AsyncQuorumCall(ctx context.Context, in *Echo) *AsyncEch
 		return c.qspec.AsyncQuorumCallQF(req.(*Echo), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncEcho{fut}
 }
 
@@ -123,12 +122,11 @@ func (c *Configuration) Multicast(ctx context.Context, in *TimedMsg, opts ...gor
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.Multicast",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // QuorumSpec is the interface of quorum functions for Benchmark.
@@ -190,7 +188,6 @@ func (c *Configuration) StartServerBenchmark(ctx context.Context, in *StartReque
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.StartServerBenchmark",
 	}
@@ -202,7 +199,7 @@ func (c *Configuration) StartServerBenchmark(ctx context.Context, in *StartReque
 		return c.qspec.StartServerBenchmarkQF(req.(*StartRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +212,6 @@ func (c *Configuration) StopServerBenchmark(ctx context.Context, in *StopRequest
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.StopServerBenchmark",
 	}
@@ -227,7 +223,7 @@ func (c *Configuration) StopServerBenchmark(ctx context.Context, in *StopRequest
 		return c.qspec.StopServerBenchmarkQF(req.(*StopRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +236,6 @@ func (c *Configuration) StartBenchmark(ctx context.Context, in *StartRequest) (r
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.StartBenchmark",
 	}
@@ -252,7 +247,7 @@ func (c *Configuration) StartBenchmark(ctx context.Context, in *StartRequest) (r
 		return c.qspec.StartBenchmarkQF(req.(*StartRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +260,6 @@ func (c *Configuration) StopBenchmark(ctx context.Context, in *StopRequest) (res
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.StopBenchmark",
 	}
@@ -277,7 +271,7 @@ func (c *Configuration) StopBenchmark(ctx context.Context, in *StopRequest) (res
 		return c.qspec.StopBenchmarkQF(req.(*StopRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +283,6 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Echo) (resp *Echo, e
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.QuorumCall",
 	}
@@ -301,7 +294,7 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Echo) (resp *Echo, e
 		return c.qspec.QuorumCallQF(req.(*Echo), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +307,6 @@ func (c *Configuration) SlowServer(ctx context.Context, in *Echo) (resp *Echo, e
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "benchmark.Benchmark.SlowServer",
 	}
@@ -326,7 +318,7 @@ func (c *Configuration) SlowServer(ctx context.Context, in *Echo) (resp *Echo, e
 		return c.qspec.SlowServerQF(req.(*Echo), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_async_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_async_gorums.pb.go
@@ -13,7 +13,6 @@ import (
 func (c *Configuration) QuorumCallAsync(ctx context.Context, in *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsync",
 	}
@@ -25,7 +24,7 @@ func (c *Configuration) QuorumCallAsync(ctx context.Context, in *Request) *Async
 		return c.qspec.QuorumCallAsyncQF(req.(*Request), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncResponse{fut}
 }
 
@@ -33,7 +32,6 @@ func (c *Configuration) QuorumCallAsync(ctx context.Context, in *Request) *Async
 func (c *Configuration) QuorumCallAsyncPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncPerNodeArg",
 	}
@@ -48,7 +46,7 @@ func (c *Configuration) QuorumCallAsyncPerNodeArg(ctx context.Context, in *Reque
 		return f(req.(*Request), nid)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncResponse{fut}
 }
 
@@ -56,7 +54,6 @@ func (c *Configuration) QuorumCallAsyncPerNodeArg(ctx context.Context, in *Reque
 func (c *Configuration) QuorumCallAsyncCustomReturnType(ctx context.Context, in *Request) *AsyncMyResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncCustomReturnType",
 	}
@@ -68,7 +65,7 @@ func (c *Configuration) QuorumCallAsyncCustomReturnType(ctx context.Context, in 
 		return c.qspec.QuorumCallAsyncCustomReturnTypeQF(req.(*Request), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncMyResponse{fut}
 }
 
@@ -76,7 +73,6 @@ func (c *Configuration) QuorumCallAsyncCustomReturnType(ctx context.Context, in 
 func (c *Configuration) QuorumCallAsyncCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *AsyncMyResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncCombo",
 	}
@@ -91,7 +87,7 @@ func (c *Configuration) QuorumCallAsyncCombo(ctx context.Context, in *Request, f
 		return f(req.(*Request), nid)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncMyResponse{fut}
 }
 
@@ -99,7 +95,6 @@ func (c *Configuration) QuorumCallAsyncCombo(ctx context.Context, in *Request, f
 func (c *Configuration) QuorumCallAsync2(ctx context.Context, in *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsync2",
 	}
@@ -111,7 +106,7 @@ func (c *Configuration) QuorumCallAsync2(ctx context.Context, in *Request) *Asyn
 		return c.qspec.QuorumCallAsync2QF(req.(*Request), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncResponse{fut}
 }
 
@@ -119,7 +114,6 @@ func (c *Configuration) QuorumCallAsync2(ctx context.Context, in *Request) *Asyn
 func (c *Configuration) QuorumCallAsyncEmpty(ctx context.Context, in *Request) *AsyncEmpty {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncEmpty",
 	}
@@ -131,7 +125,7 @@ func (c *Configuration) QuorumCallAsyncEmpty(ctx context.Context, in *Request) *
 		return c.qspec.QuorumCallAsyncEmptyQF(req.(*Request), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncEmpty{fut}
 }
 
@@ -140,7 +134,6 @@ func (c *Configuration) QuorumCallAsyncEmpty(ctx context.Context, in *Request) *
 func (c *Configuration) QuorumCallAsyncEmpty2(ctx context.Context, in *emptypb.Empty) *AsyncResponse {
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncEmpty2",
 	}
@@ -152,6 +145,6 @@ func (c *Configuration) QuorumCallAsyncEmpty2(ctx context.Context, in *emptypb.E
 		return c.qspec.QuorumCallAsyncEmpty2QF(req.(*emptypb.Empty), r)
 	}
 
-	fut := gorums.AsyncCall(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &AsyncResponse{fut}
 }

--- a/cmd/protoc-gen-gorums/dev/zorums_async_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_async_gorums.pb.go
@@ -12,7 +12,6 @@ import (
 // QuorumCallAsync plain.
 func (c *Configuration) QuorumCallAsync(ctx context.Context, in *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsync",
 	}
@@ -31,7 +30,6 @@ func (c *Configuration) QuorumCallAsync(ctx context.Context, in *Request) *Async
 // QuorumCallAsyncPerNodeArg with per_node_arg option.
 func (c *Configuration) QuorumCallAsyncPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncPerNodeArg",
 	}
@@ -53,7 +51,6 @@ func (c *Configuration) QuorumCallAsyncPerNodeArg(ctx context.Context, in *Reque
 // QuorumCallAsyncCustomReturnType with custom_return_type option.
 func (c *Configuration) QuorumCallAsyncCustomReturnType(ctx context.Context, in *Request) *AsyncMyResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncCustomReturnType",
 	}
@@ -72,7 +69,6 @@ func (c *Configuration) QuorumCallAsyncCustomReturnType(ctx context.Context, in 
 // QuorumCallAsyncCombo with all supported options.
 func (c *Configuration) QuorumCallAsyncCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *AsyncMyResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncCombo",
 	}
@@ -94,7 +90,6 @@ func (c *Configuration) QuorumCallAsyncCombo(ctx context.Context, in *Request, f
 // QuorumCallAsync2 plain; with same return type: Response.
 func (c *Configuration) QuorumCallAsync2(ctx context.Context, in *Request) *AsyncResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsync2",
 	}
@@ -113,7 +108,6 @@ func (c *Configuration) QuorumCallAsync2(ctx context.Context, in *Request) *Asyn
 // QuorumCallAsyncEmpty for testing imported message type.
 func (c *Configuration) QuorumCallAsyncEmpty(ctx context.Context, in *Request) *AsyncEmpty {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncEmpty",
 	}
@@ -133,7 +127,6 @@ func (c *Configuration) QuorumCallAsyncEmpty(ctx context.Context, in *Request) *
 // type as QuorumCallAsync: Response.
 func (c *Configuration) QuorumCallAsyncEmpty2(ctx context.Context, in *emptypb.Empty) *AsyncResponse {
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallAsyncEmpty2",
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_correctable_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_correctable_gorums.pb.go
@@ -13,7 +13,6 @@ import (
 func (c *Configuration) Correctable(ctx context.Context, in *Request) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.Correctable",
 		ServerStream: false,
@@ -26,7 +25,7 @@ func (c *Configuration) Correctable(ctx context.Context, in *Request) *Correctab
 		return c.qspec.CorrectableQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableResponse{corr}
 }
 
@@ -34,7 +33,6 @@ func (c *Configuration) Correctable(ctx context.Context, in *Request) *Correctab
 func (c *Configuration) CorrectablePerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectablePerNodeArg",
 		ServerStream: false,
@@ -50,7 +48,7 @@ func (c *Configuration) CorrectablePerNodeArg(ctx context.Context, in *Request, 
 		return f(req.(*Request), nid)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableResponse{corr}
 }
 
@@ -58,7 +56,6 @@ func (c *Configuration) CorrectablePerNodeArg(ctx context.Context, in *Request, 
 func (c *Configuration) CorrectableCustomReturnType(ctx context.Context, in *Request) *CorrectableMyResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableCustomReturnType",
 		ServerStream: false,
@@ -71,7 +68,7 @@ func (c *Configuration) CorrectableCustomReturnType(ctx context.Context, in *Req
 		return c.qspec.CorrectableCustomReturnTypeQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableMyResponse{corr}
 }
 
@@ -79,7 +76,6 @@ func (c *Configuration) CorrectableCustomReturnType(ctx context.Context, in *Req
 func (c *Configuration) CorrectableCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableMyResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableCombo",
 		ServerStream: false,
@@ -95,7 +91,7 @@ func (c *Configuration) CorrectableCombo(ctx context.Context, in *Request, f fun
 		return f(req.(*Request), nid)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableMyResponse{corr}
 }
 
@@ -103,7 +99,6 @@ func (c *Configuration) CorrectableCombo(ctx context.Context, in *Request, f fun
 func (c *Configuration) CorrectableEmpty(ctx context.Context, in *Request) *CorrectableEmpty {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableEmpty",
 		ServerStream: false,
@@ -116,7 +111,7 @@ func (c *Configuration) CorrectableEmpty(ctx context.Context, in *Request) *Corr
 		return c.qspec.CorrectableEmptyQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableEmpty{corr}
 }
 
@@ -125,7 +120,6 @@ func (c *Configuration) CorrectableEmpty(ctx context.Context, in *Request) *Corr
 func (c *Configuration) CorrectableEmpty2(ctx context.Context, in *emptypb.Empty) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableEmpty2",
 		ServerStream: false,
@@ -138,7 +132,7 @@ func (c *Configuration) CorrectableEmpty2(ctx context.Context, in *emptypb.Empty
 		return c.qspec.CorrectableEmpty2QF(req.(*emptypb.Empty), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableResponse{corr}
 }
 
@@ -146,7 +140,6 @@ func (c *Configuration) CorrectableEmpty2(ctx context.Context, in *emptypb.Empty
 func (c *Configuration) CorrectableStream(ctx context.Context, in *Request) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStream",
 		ServerStream: true,
@@ -159,7 +152,7 @@ func (c *Configuration) CorrectableStream(ctx context.Context, in *Request) *Cor
 		return c.qspec.CorrectableStreamQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamResponse{corr}
 }
 
@@ -167,7 +160,6 @@ func (c *Configuration) CorrectableStream(ctx context.Context, in *Request) *Cor
 func (c *Configuration) CorrectableStreamPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamPerNodeArg",
 		ServerStream: true,
@@ -183,7 +175,7 @@ func (c *Configuration) CorrectableStreamPerNodeArg(ctx context.Context, in *Req
 		return f(req.(*Request), nid)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamResponse{corr}
 }
 
@@ -191,7 +183,6 @@ func (c *Configuration) CorrectableStreamPerNodeArg(ctx context.Context, in *Req
 func (c *Configuration) CorrectableStreamCustomReturnType(ctx context.Context, in *Request) *CorrectableStreamMyResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamCustomReturnType",
 		ServerStream: true,
@@ -204,7 +195,7 @@ func (c *Configuration) CorrectableStreamCustomReturnType(ctx context.Context, i
 		return c.qspec.CorrectableStreamCustomReturnTypeQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamMyResponse{corr}
 }
 
@@ -212,7 +203,6 @@ func (c *Configuration) CorrectableStreamCustomReturnType(ctx context.Context, i
 func (c *Configuration) CorrectableStreamCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableStreamMyResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamCombo",
 		ServerStream: true,
@@ -228,7 +218,7 @@ func (c *Configuration) CorrectableStreamCombo(ctx context.Context, in *Request,
 		return f(req.(*Request), nid)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamMyResponse{corr}
 }
 
@@ -236,7 +226,6 @@ func (c *Configuration) CorrectableStreamCombo(ctx context.Context, in *Request,
 func (c *Configuration) CorrectableStreamEmpty(ctx context.Context, in *Request) *CorrectableStreamEmpty {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamEmpty",
 		ServerStream: true,
@@ -249,7 +238,7 @@ func (c *Configuration) CorrectableStreamEmpty(ctx context.Context, in *Request)
 		return c.qspec.CorrectableStreamEmptyQF(req.(*Request), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamEmpty{corr}
 }
 
@@ -258,7 +247,6 @@ func (c *Configuration) CorrectableStreamEmpty(ctx context.Context, in *Request)
 func (c *Configuration) CorrectableStreamEmpty2(ctx context.Context, in *emptypb.Empty) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
 		Manager:      c.mgr.Manager,
-		Nodes:        c.Configuration.Nodes(),
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamEmpty2",
 		ServerStream: true,
@@ -271,6 +259,6 @@ func (c *Configuration) CorrectableStreamEmpty2(ctx context.Context, in *emptypb
 		return c.qspec.CorrectableStreamEmpty2QF(req.(*emptypb.Empty), r)
 	}
 
-	corr := gorums.CorrectableCall(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &CorrectableStreamResponse{corr}
 }

--- a/cmd/protoc-gen-gorums/dev/zorums_correctable_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_correctable_gorums.pb.go
@@ -12,7 +12,6 @@ import (
 // Correctable plain.
 func (c *Configuration) Correctable(ctx context.Context, in *Request) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.Correctable",
 		ServerStream: false,
@@ -32,7 +31,6 @@ func (c *Configuration) Correctable(ctx context.Context, in *Request) *Correctab
 // CorrectablePerNodeArg with per_node_arg option.
 func (c *Configuration) CorrectablePerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectablePerNodeArg",
 		ServerStream: false,
@@ -55,7 +53,6 @@ func (c *Configuration) CorrectablePerNodeArg(ctx context.Context, in *Request, 
 // CorrectableCustomReturnType with custom_return_type option.
 func (c *Configuration) CorrectableCustomReturnType(ctx context.Context, in *Request) *CorrectableMyResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableCustomReturnType",
 		ServerStream: false,
@@ -75,7 +72,6 @@ func (c *Configuration) CorrectableCustomReturnType(ctx context.Context, in *Req
 // CorrectableCombo with all supported options.
 func (c *Configuration) CorrectableCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableMyResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableCombo",
 		ServerStream: false,
@@ -98,7 +94,6 @@ func (c *Configuration) CorrectableCombo(ctx context.Context, in *Request, f fun
 // CorrectableEmpty for testing imported message type.
 func (c *Configuration) CorrectableEmpty(ctx context.Context, in *Request) *CorrectableEmpty {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableEmpty",
 		ServerStream: false,
@@ -119,7 +114,6 @@ func (c *Configuration) CorrectableEmpty(ctx context.Context, in *Request) *Corr
 // type as Correctable: Response.
 func (c *Configuration) CorrectableEmpty2(ctx context.Context, in *emptypb.Empty) *CorrectableResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableEmpty2",
 		ServerStream: false,
@@ -139,7 +133,6 @@ func (c *Configuration) CorrectableEmpty2(ctx context.Context, in *emptypb.Empty
 // CorrectableStream plain.
 func (c *Configuration) CorrectableStream(ctx context.Context, in *Request) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStream",
 		ServerStream: true,
@@ -159,7 +152,6 @@ func (c *Configuration) CorrectableStream(ctx context.Context, in *Request) *Cor
 // CorrectablePerNodeArg with per_node_arg option.
 func (c *Configuration) CorrectableStreamPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamPerNodeArg",
 		ServerStream: true,
@@ -182,7 +174,6 @@ func (c *Configuration) CorrectableStreamPerNodeArg(ctx context.Context, in *Req
 // CorrectableCustomReturnType with custom_return_type option.
 func (c *Configuration) CorrectableStreamCustomReturnType(ctx context.Context, in *Request) *CorrectableStreamMyResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamCustomReturnType",
 		ServerStream: true,
@@ -202,7 +193,6 @@ func (c *Configuration) CorrectableStreamCustomReturnType(ctx context.Context, i
 // CorrectableCombo with all supported options.
 func (c *Configuration) CorrectableStreamCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) *CorrectableStreamMyResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamCombo",
 		ServerStream: true,
@@ -225,7 +215,6 @@ func (c *Configuration) CorrectableStreamCombo(ctx context.Context, in *Request,
 // CorrectableEmpty for testing imported message type.
 func (c *Configuration) CorrectableStreamEmpty(ctx context.Context, in *Request) *CorrectableStreamEmpty {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamEmpty",
 		ServerStream: true,
@@ -246,7 +235,6 @@ func (c *Configuration) CorrectableStreamEmpty(ctx context.Context, in *Request)
 // type as Correctable: Response.
 func (c *Configuration) CorrectableStreamEmpty2(ctx context.Context, in *emptypb.Empty) *CorrectableStreamResponse {
 	cd := gorums.CorrectableCallData{
-		Manager:      c.mgr.Manager,
 		Message:      in,
 		Method:       "dev.ZorumsService.CorrectableStreamEmpty2",
 		ServerStream: true,

--- a/cmd/protoc-gen-gorums/dev/zorums_multicast_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_multicast_gorums.pb.go
@@ -14,12 +14,11 @@ func (c *Configuration) Multicast(ctx context.Context, in *Request, opts ...goru
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // MulticastPerNodeArg with per_node_arg option.
@@ -27,7 +26,6 @@ func (c *Configuration) MulticastPerNodeArg(ctx context.Context, in *Request, f 
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.MulticastPerNodeArg",
 	}
@@ -36,7 +34,7 @@ func (c *Configuration) MulticastPerNodeArg(ctx context.Context, in *Request, f 
 		return f(req.(*Request), nid)
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // Multicast2 is testing whether multiple streams work.
@@ -44,12 +42,11 @@ func (c *Configuration) Multicast2(ctx context.Context, in *Request, opts ...gor
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast2",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -60,12 +57,11 @@ func (c *Configuration) Multicast3(ctx context.Context, in *Request, opts ...gor
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast3",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -76,10 +72,9 @@ func (c *Configuration) Multicast4(ctx context.Context, in *emptypb.Empty, opts 
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast4",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }

--- a/cmd/protoc-gen-gorums/dev/zorums_multicast_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_multicast_gorums.pb.go
@@ -11,9 +11,7 @@ import (
 
 // Multicast plain. Response type is not needed here.
 func (c *Configuration) Multicast(ctx context.Context, in *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast",
 	}
@@ -23,9 +21,7 @@ func (c *Configuration) Multicast(ctx context.Context, in *Request, opts ...goru
 
 // MulticastPerNodeArg with per_node_arg option.
 func (c *Configuration) MulticastPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.MulticastPerNodeArg",
 	}
@@ -39,9 +35,7 @@ func (c *Configuration) MulticastPerNodeArg(ctx context.Context, in *Request, f 
 
 // Multicast2 is testing whether multiple streams work.
 func (c *Configuration) Multicast2(ctx context.Context, in *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast2",
 	}
@@ -54,9 +48,7 @@ var _ emptypb.Empty
 
 // Multicast3 is testing imported message type.
 func (c *Configuration) Multicast3(ctx context.Context, in *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast3",
 	}
@@ -69,9 +61,7 @@ var _ emptypb.Empty
 
 // Multicast4 is testing imported message type.
 func (c *Configuration) Multicast4(ctx context.Context, in *emptypb.Empty, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.Multicast4",
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_quorumcall_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_quorumcall_gorums.pb.go
@@ -11,9 +11,7 @@ import (
 
 // QuorumCall plain.
 func (c *Configuration) QuorumCall(ctx context.Context, in *Request) (resp *Response, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCall",
 	}
@@ -34,9 +32,7 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Request) (resp *Resp
 
 // QuorumCall with per_node_arg option.
 func (c *Configuration) QuorumCallPerNodeArg(ctx context.Context, in *Request, f func(*Request, uint32) *Request) (resp *Response, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallPerNodeArg",
 	}
@@ -60,9 +56,7 @@ func (c *Configuration) QuorumCallPerNodeArg(ctx context.Context, in *Request, f
 
 // QuorumCall with custom_return_type option.
 func (c *Configuration) QuorumCallCustomReturnType(ctx context.Context, in *Request) (resp *MyResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallCustomReturnType",
 	}
@@ -83,9 +77,7 @@ func (c *Configuration) QuorumCallCustomReturnType(ctx context.Context, in *Requ
 
 // QuorumCallCombo with all supported options.
 func (c *Configuration) QuorumCallCombo(ctx context.Context, in *Request, f func(*Request, uint32) *Request) (resp *MyResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallCombo",
 	}
@@ -109,9 +101,7 @@ func (c *Configuration) QuorumCallCombo(ctx context.Context, in *Request, f func
 
 // QuorumCallEmpty for testing imported message type.
 func (c *Configuration) QuorumCallEmpty(ctx context.Context, in *emptypb.Empty) (resp *Response, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallEmpty",
 	}
@@ -132,9 +122,7 @@ func (c *Configuration) QuorumCallEmpty(ctx context.Context, in *emptypb.Empty) 
 
 // QuorumCallEmpty2 for testing imported message type.
 func (c *Configuration) QuorumCallEmpty2(ctx context.Context, in *Request) (resp *emptypb.Empty, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallEmpty2",
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_quorumcall_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_quorumcall_gorums.pb.go
@@ -14,7 +14,6 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Request) (resp *Resp
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCall",
 	}
@@ -26,7 +25,7 @@ func (c *Configuration) QuorumCall(ctx context.Context, in *Request) (resp *Resp
 		return c.qspec.QuorumCallQF(req.(*Request), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +37,6 @@ func (c *Configuration) QuorumCallPerNodeArg(ctx context.Context, in *Request, f
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallPerNodeArg",
 	}
@@ -53,7 +51,7 @@ func (c *Configuration) QuorumCallPerNodeArg(ctx context.Context, in *Request, f
 		return f(req.(*Request), nid)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +63,6 @@ func (c *Configuration) QuorumCallCustomReturnType(ctx context.Context, in *Requ
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallCustomReturnType",
 	}
@@ -77,7 +74,7 @@ func (c *Configuration) QuorumCallCustomReturnType(ctx context.Context, in *Requ
 		return c.qspec.QuorumCallCustomReturnTypeQF(req.(*Request), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +86,6 @@ func (c *Configuration) QuorumCallCombo(ctx context.Context, in *Request, f func
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallCombo",
 	}
@@ -104,7 +100,7 @@ func (c *Configuration) QuorumCallCombo(ctx context.Context, in *Request, f func
 		return f(req.(*Request), nid)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +112,6 @@ func (c *Configuration) QuorumCallEmpty(ctx context.Context, in *emptypb.Empty) 
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallEmpty",
 	}
@@ -128,7 +123,7 @@ func (c *Configuration) QuorumCallEmpty(ctx context.Context, in *emptypb.Empty) 
 		return c.qspec.QuorumCallEmptyQF(req.(*emptypb.Empty), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +135,6 @@ func (c *Configuration) QuorumCallEmpty2(ctx context.Context, in *Request) (resp
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.Configuration.Nodes(),
 		Message: in,
 		Method:  "dev.ZorumsService.QuorumCallEmpty2",
 	}
@@ -152,7 +146,7 @@ func (c *Configuration) QuorumCallEmpty2(ctx context.Context, in *Request) (resp
 		return c.qspec.QuorumCallEmpty2QF(req.(*Request), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_rpc_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_rpc_gorums.pb.go
@@ -10,14 +10,12 @@ import (
 // GRPCCall plain gRPC call; testing that Gorums can ignore these, but that
 // they are added to the _grpc.pb.go generated file.
 func (n *Node) GRPCCall(ctx context.Context, in *Request) (resp *Response, err error) {
-
 	cd := gorums.CallData{
-		Node:    n.Node,
 		Message: in,
 		Method:  "dev.ZorumsService.GRPCCall",
 	}
 
-	res, err := gorums.RPCCall(ctx, cd)
+	res, err := n.Node.RPCCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/protoc-gen-gorums/dev/zorums_unicast_gorums.pb.go
+++ b/cmd/protoc-gen-gorums/dev/zorums_unicast_gorums.pb.go
@@ -11,14 +11,12 @@ import (
 // Unicast is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (n *Node) Unicast(ctx context.Context, in *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.CallData{
-		Node:    n.Node,
 		Message: in,
 		Method:  "dev.ZorumsService.Unicast",
 	}
 
-	gorums.Unicast(ctx, cd, opts...)
+	n.Node.Unicast(ctx, cd, opts...)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -27,12 +25,10 @@ var _ emptypb.Empty
 // Unicast2 is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (n *Node) Unicast2(ctx context.Context, in *Request, opts ...gorums.CallOption) {
-
 	cd := gorums.CallData{
-		Node:    n.Node,
 		Message: in,
 		Method:  "dev.ZorumsService.Unicast2",
 	}
 
-	gorums.Unicast(ctx, cd, opts...)
+	n.Node.Unicast(ctx, cd, opts...)
 }

--- a/cmd/protoc-gen-gorums/gengorums/template_async.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_async.go
@@ -32,10 +32,9 @@ var asyncVar = qcVar + `
 
 var asyncBody = `
 	cd := {{$callData}}{
-		Manager:  c.mgr.Manager,
-		Nodes:    c.Configuration.Nodes(),
-		Message:  in,
-		Method:   "{{$fullName}}",
+		Manager: c.mgr.Manager,
+		Message: in,
+		Method:  "{{$fullName}}",
 	}
 	cd.QuorumFunction = func(req {{$protoMessage}}, replies map[uint32]{{$protoMessage}}) ({{$protoMessage}}, bool) {
 		r := make(map[uint32]*{{$out}}, len(replies))
@@ -50,7 +49,7 @@ var asyncBody = `
 	}
 {{- end}}
 
-	fut := {{use "gorums.AsyncCall" $genFile}}(ctx, cd)
+	fut := c.Configuration.AsyncCall(ctx, cd)
 	return &{{$asyncOut}}{fut}
 }
 `

--- a/cmd/protoc-gen-gorums/gengorums/template_async.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_async.go
@@ -30,9 +30,7 @@ var asyncVar = qcVar + `
 {{$asyncOut := outType .Method $customOut}}
 `
 
-var asyncBody = `
-	cd := {{$callData}}{
-		Manager: c.mgr.Manager,
+var asyncBody = `	cd := {{$callData}}{
 		Message: in,
 		Method:  "{{$fullName}}",
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_correctable.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_correctable.go
@@ -40,10 +40,9 @@ var correctableSignature = `func (c *Configuration) {{$method}}(` +
 
 var correctableBody = `
 	cd := {{$callData}}{
-		Manager:  c.mgr.Manager,
-		Nodes:    c.Configuration.Nodes(),
-		Message:  in,
-		Method: "{{$fullName}}",
+		Manager: c.mgr.Manager,
+		Message: in,
+		Method:  "{{$fullName}}",
 	{{- if correctableStream .Method}}
 		ServerStream: true,
 	{{- else}}
@@ -63,7 +62,7 @@ var correctableBody = `
 	}
 {{- end}}
 
-	corr := {{use "gorums.CorrectableCall" $genFile}}(ctx, cd)
+	corr := c.Configuration.CorrectableCall(ctx, cd)
 	return &{{$correctableOut}}{corr}
 }
 `

--- a/cmd/protoc-gen-gorums/gengorums/template_correctable.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_correctable.go
@@ -38,9 +38,7 @@ var correctableSignature = `func (c *Configuration) {{$method}}(` +
 	`{{perNodeFnType .GenFile .Method ", f"}}) ` +
 	`*{{$correctableOut}} {`
 
-var correctableBody = `
-	cd := {{$callData}}{
-		Manager: c.mgr.Manager,
+var correctableBody = `	cd := {{$callData}}{
 		Message: in,
 		Method:  "{{$fullName}}",
 	{{- if correctableStream .Method}}

--- a/cmd/protoc-gen-gorums/gengorums/template_multicast.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_multicast.go
@@ -21,9 +21,7 @@ var multicastSignature = `func (c *Configuration) {{$method}}(` +
 	`opts ...{{$callOpt}}) {
 `
 
-var multicastBody = `
-	cd := {{$callData}}{
-		Manager: c.mgr.Manager,
+var multicastBody = `	cd := {{$callData}}{
 		Message: in,
 		Method:  "{{$fullName}}",
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_multicast.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_multicast.go
@@ -23,10 +23,9 @@ var multicastSignature = `func (c *Configuration) {{$method}}(` +
 
 var multicastBody = `
 	cd := {{$callData}}{
-		Manager:  c.mgr.Manager,
-		Nodes:    c.Configuration.Nodes(),
-		Message:  in,
-		Method: "{{$fullName}}",
+		Manager: c.mgr.Manager,
+		Message: in,
+		Method:  "{{$fullName}}",
 	}
 {{- if hasPerNodeArg .Method}}
 {{$protoMessage := use "protoreflect.ProtoMessage" .GenFile}}
@@ -35,7 +34,7 @@ var multicastBody = `
 	}
 {{- end}}
 
-	{{use "gorums.Multicast" $genFile}}(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 `
 

--- a/cmd/protoc-gen-gorums/gengorums/template_quorumcall.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_quorumcall.go
@@ -44,9 +44,7 @@ var qcVar = `
 {{$context := use "context.Context" .GenFile}}
 `
 
-var quorumCallBody = `
-	cd := {{$callData}}{
-		Manager: c.mgr.Manager,
+var quorumCallBody = `	cd := {{$callData}}{
 		Message: in,
 		Method:  "{{$fullName}}",
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_quorumcall.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_quorumcall.go
@@ -46,10 +46,9 @@ var qcVar = `
 
 var quorumCallBody = `
 	cd := {{$callData}}{
-		Manager:  c.mgr.Manager,
-		Nodes:    c.Configuration.Nodes(),
-		Message:  in,
-		Method: "{{$fullName}}",
+		Manager: c.mgr.Manager,
+		Message: in,
+		Method:  "{{$fullName}}",
 	}
 	cd.QuorumFunction = func(req {{$protoMessage}}, replies map[uint32]{{$protoMessage}}) ({{$protoMessage}}, bool) {
 		r := make(map[uint32]*{{$out}}, len(replies))
@@ -64,7 +63,7 @@ var quorumCallBody = `
 	}
 {{- end}}
 
-	res, err := {{use "gorums.QuorumCall" $genFile}}(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_rpc.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_rpc.go
@@ -12,9 +12,7 @@ var rpcVar = `
 {{$context := use "context.Context" .GenFile}}
 `
 
-var rpcBody = `
-	cd := {{$callData}}{
-		Node:     n.Node,
+var rpcBody = `	cd := {{$callData}}{
 		Message:  in,
 		Method: "{{$fullName}}",
 	}
@@ -25,7 +23,7 @@ var rpcBody = `
 	}
 {{- end}}
 
-	res, err := {{use "gorums.RPCCall" $genFile}}(ctx, cd)
+	res, err := n.Node.RPCCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/protoc-gen-gorums/gengorums/template_unicast.go
+++ b/cmd/protoc-gen-gorums/gengorums/template_unicast.go
@@ -6,14 +6,12 @@ var unicastSignature = `func (n *Node) {{$method}}(` +
 	`ctx {{$context}}, in *{{$in}}, opts ...{{$callOpt}}) {
 `
 
-var unicastBody = `
-	cd := {{$callData}}{
-		Node:     n.Node,
+var unicastBody = `	cd := {{$callData}}{
 		Message:  in,
 		Method: "{{$fullName}}",
 	}
 
-	{{use "gorums.Unicast" $genFile}}(ctx, cd, opts...)
+	n.Node.Unicast(ctx, cd, opts...)
 }
 `
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package gorums
 
 import (
 	"sort"
+
+	"github.com/relab/gorums/ordering"
 )
 
 // Configuration represents a static set of nodes on which quorum calls may be invoked.
@@ -53,4 +55,19 @@ func (c Configuration) Nodes() []*Node {
 // Size returns the number of nodes in this configuration.
 func (c Configuration) Size() int {
 	return len(c)
+}
+
+// newCall returns unique metadata for a method call.
+func (c Configuration) newCall(method string) (md *ordering.Metadata) {
+	// Note that we just use the first node's newCall method since all nodes
+	// associated with the same manager use the same receiveQueue instance.
+	return c[0].newCall(method)
+}
+
+// newReply returns a channel for receiving replies
+// and a done function to be called for clean up.
+func (c Configuration) newReply(md *ordering.Metadata, maxReplies int) (replyChan chan *gorumsStreamResult, done func()) {
+	// Note that we just use the first node's newReply method since all nodes
+	// associated with the same manager use the same receiveQueue instance.
+	return c[0].newReply(md, maxReplies)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -16,7 +16,7 @@ func TestNewConfigurationNodeList(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.Size() != len(nodes) {
-		t.Errorf("cfg.Size() = %d, expected %d", mgr.Size(), len(nodes))
+		t.Errorf("cfg.Size() = %d, expected %d", cfg.Size(), len(nodes))
 	}
 
 	contains := func(nodes []*gorums.Node, addr string) bool {
@@ -45,7 +45,7 @@ func TestNewConfigurationNodeMap(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.Size() != len(nodeMap) {
-		t.Errorf("cfg.Size() = %d, expected %d", mgr.Size(), len(nodeMap))
+		t.Errorf("cfg.Size() = %d, expected %d", cfg.Size(), len(nodeMap))
 	}
 	for _, node := range cfg.Nodes() {
 		if nodeMap[node.Address()] != node.ID() {

--- a/correctable.go
+++ b/correctable.go
@@ -74,7 +74,6 @@ func (c *Correctable) set(reply protoreflect.ProtoMessage, level int, err error,
 
 type CorrectableCallData struct {
 	Manager        *Manager
-	Nodes          []*Node
 	Message        protoreflect.ProtoMessage
 	Method         string
 	PerNodeArgFn   func(protoreflect.ProtoMessage, uint32) protoreflect.ProtoMessage
@@ -82,12 +81,12 @@ type CorrectableCallData struct {
 	ServerStream   bool
 }
 
-func CorrectableCall(ctx context.Context, d CorrectableCallData) *Correctable {
-	expectedReplies := len(d.Nodes)
+func (c Configuration) CorrectableCall(ctx context.Context, d CorrectableCallData) *Correctable {
+	expectedReplies := len(c)
 	md := d.Manager.newCall(d.Method)
 	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 
-	for _, n := range d.Nodes {
+	for _, n := range c {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
 			msg = d.PerNodeArgFn(d.Message, n.id)

--- a/correctable.go
+++ b/correctable.go
@@ -73,7 +73,6 @@ func (c *Correctable) set(reply protoreflect.ProtoMessage, level int, err error,
 }
 
 type CorrectableCallData struct {
-	Manager        *Manager
 	Message        protoreflect.ProtoMessage
 	Method         string
 	PerNodeArgFn   func(protoreflect.ProtoMessage, uint32) protoreflect.ProtoMessage
@@ -83,8 +82,8 @@ type CorrectableCallData struct {
 
 func (c Configuration) CorrectableCall(ctx context.Context, d CorrectableCallData) *Correctable {
 	expectedReplies := len(c)
-	md := d.Manager.newCall(d.Method)
-	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
+	md := c.newCall(d.Method)
+	replyChan, callDone := c.newReply(md, expectedReplies)
 
 	for _, n := range c {
 		msg := d.Message

--- a/examples/storage/proto/storage_gorums.pb.go
+++ b/examples/storage/proto/storage_gorums.pb.go
@@ -9,18 +9,26 @@ import (
 	encoding "google.golang.org/grpc/encoding"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	sort "sort"
 	sync "sync"
 )
 
 // A Configuration represents a static set of nodes on which quorum remote
 // procedure calls may be invoked.
 type Configuration struct {
-	id    uint32
-	nodes []*gorums.Node
+	gorums.Configuration
 	mgr   *Manager
 	qspec QuorumSpec
-	errs  chan gorums.Error
+}
+
+// Nodes returns a slice of each available node. IDs are returned in the same
+// order as they were provided in the creation of the Manager.
+func (c *Configuration) Nodes() []*Node {
+	gorumsNodes := c.Configuration.Nodes()
+	nodes := make([]*Node, 0, len(gorumsNodes))
+	for _, n := range gorumsNodes {
+		nodes = append(nodes, &Node{n})
+	}
+	return nodes
 }
 
 // NewConfig returns a configuration for the given node addresses and quorum spec.
@@ -38,55 +46,14 @@ func NewConfig(qspec QuorumSpec, opts ...gorums.ManagerOption) (*Configuration, 
 	return c, func() { man.Close() }, nil
 }
 
-// ID reports the identifier for the configuration.
-func (c *Configuration) ID() uint32 {
-	return c.id
-}
-
-// NodeIDs returns a slice containing the local ids of all the nodes in the
-// configuration. IDs are returned in the same order as they were provided in
-// the creation of the Configuration.
-func (c *Configuration) NodeIDs() []uint32 {
-	ids := make([]uint32, len(c.nodes))
-	for i, node := range c.nodes {
-		ids[i] = node.ID()
-	}
-	return ids
-}
-
-// Nodes returns a slice of each available node. IDs are returned in the same
-// order as they were provided in the creation of the Configuration.
-func (c *Configuration) Nodes() []*Node {
-	nodes := make([]*Node, 0, len(c.nodes))
-	for _, n := range c.nodes {
-		nodes = append(nodes, &Node{n})
-	}
-	return nodes
-}
-
-// Size returns the number of nodes in the configuration.
-func (c *Configuration) Size() int {
-	return len(c.nodes)
-}
-
-func (c *Configuration) String() string {
-	return fmt.Sprintf("config-%d", c.id)
-}
-
-// Equal returns a boolean reporting whether a and b represents the same
-// configuration.
-func Equal(a, b *Configuration) bool { return a.id == b.id }
-
-// SubError returns a channel for listening to individual node errors. Currently
-// only a single listener is supported.
-func (c *Configuration) SubError() <-chan gorums.Error {
-	return c.errs
-}
-
 func init() {
 	if encoding.GetCodec(gorums.ContentSubtype) == nil {
 		encoding.RegisterCodec(gorums.NewCodec())
 	}
+}
+
+type Manager struct {
+	*gorums.Manager
 }
 
 func NewManager(opts ...gorums.ManagerOption) (mgr *Manager, err error) {
@@ -98,47 +65,20 @@ func NewManager(opts ...gorums.ManagerOption) (mgr *Manager, err error) {
 	return mgr, nil
 }
 
-type Manager struct {
-	*gorums.Manager
-}
-
-func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (*Configuration, error) {
-	if len(ids) == 0 {
-		return nil, gorums.IllegalConfigError("need at least one node")
-	}
-
-	var nodes []*gorums.Node
-	unique := make(map[uint32]struct{})
-	for _, nid := range ids {
-		// ensure that identical IDs are only counted once
-		if _, duplicate := unique[nid]; duplicate {
-			continue
-		}
-		unique[nid] = struct{}{}
-
-		node, found := m.Node(nid)
-		if !found {
-			return nil, gorums.NodeNotFoundError(nid)
-		}
-
-		i := sort.Search(len(nodes), func(i int) bool {
-			return node.ID() < nodes[i].ID()
-		})
-		nodes = append(nodes, nil)
-		copy(nodes[i+1:], nodes[i:])
-		nodes[i] = node
-	}
-
-	c := &Configuration{
-		nodes: nodes,
+func (m *Manager) NewConfiguration(ids []uint32, qspec QuorumSpec) (c *Configuration, err error) {
+	c = &Configuration{
 		mgr:   m,
 		qspec: qspec,
+	}
+	c.Configuration, err = gorums.NewConfiguration(m.Manager, ids)
+	if err != nil {
+		return nil, err
 	}
 	return c, nil
 }
 
-// Nodes returns a slice of each available node. IDs are returned in the same
-// order as they were provided in the creation of the Manager.
+// Nodes returns a slice of available nodes on this manager.
+// IDs are returned in the order they were added at creation of the manager.
 func (m *Manager) Nodes() []*Node {
 	gorumsNodes := m.Manager.Nodes()
 	nodes := make([]*Node, 0, len(gorumsNodes))
@@ -161,12 +101,11 @@ func (c *Configuration) WriteMulticast(ctx context.Context, in *WriteRequest, op
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.nodes,
 		Message: in,
 		Method:  "storage.Storage.WriteMulticast",
 	}
 
-	gorums.Multicast(ctx, cd, opts...)
+	c.Configuration.Multicast(ctx, cd, opts...)
 }
 
 // QuorumSpec is the interface of quorum functions for Storage.
@@ -193,7 +132,6 @@ func (c *Configuration) ReadQC(ctx context.Context, in *ReadRequest) (resp *Read
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.nodes,
 		Message: in,
 		Method:  "storage.Storage.ReadQC",
 	}
@@ -205,7 +143,7 @@ func (c *Configuration) ReadQC(ctx context.Context, in *ReadRequest) (resp *Read
 		return c.qspec.ReadQCQF(req.(*ReadRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +156,6 @@ func (c *Configuration) WriteQC(ctx context.Context, in *WriteRequest) (resp *Wr
 
 	cd := gorums.QuorumCallData{
 		Manager: c.mgr.Manager,
-		Nodes:   c.nodes,
 		Message: in,
 		Method:  "storage.Storage.WriteQC",
 	}
@@ -230,7 +167,7 @@ func (c *Configuration) WriteQC(ctx context.Context, in *WriteRequest) (resp *Wr
 		return c.qspec.WriteQCQF(req.(*WriteRequest), r)
 	}
 
-	res, err := gorums.QuorumCall(ctx, cd)
+	res, err := c.Configuration.QuorumCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/storage/proto/storage_gorums.pb.go
+++ b/examples/storage/proto/storage_gorums.pb.go
@@ -176,14 +176,12 @@ func (c *Configuration) WriteQC(ctx context.Context, in *WriteRequest) (resp *Wr
 
 // ReadRPC executes the Read RPC on a single Node
 func (n *Node) ReadRPC(ctx context.Context, in *ReadRequest) (resp *ReadResponse, err error) {
-
 	cd := gorums.CallData{
-		Node:    n.Node,
 		Message: in,
 		Method:  "storage.Storage.ReadRPC",
 	}
 
-	res, err := gorums.RPCCall(ctx, cd)
+	res, err := n.Node.RPCCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}
@@ -192,14 +190,12 @@ func (n *Node) ReadRPC(ctx context.Context, in *ReadRequest) (resp *ReadResponse
 
 // WriteRPC executes the Write RPC on a single Node
 func (n *Node) WriteRPC(ctx context.Context, in *WriteRequest) (resp *WriteResponse, err error) {
-
 	cd := gorums.CallData{
-		Node:    n.Node,
 		Message: in,
 		Method:  "storage.Storage.WriteRPC",
 	}
 
-	res, err := gorums.RPCCall(ctx, cd)
+	res, err := n.Node.RPCCall(ctx, cd)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/storage/proto/storage_gorums.pb.go
+++ b/examples/storage/proto/storage_gorums.pb.go
@@ -98,9 +98,7 @@ var _ emptypb.Empty
 // WriteMulticast is a quorum call invoked on all nodes in configuration c,
 // with the same argument in, and returns a combined result.
 func (c *Configuration) WriteMulticast(ctx context.Context, in *WriteRequest, opts ...gorums.CallOption) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "storage.Storage.WriteMulticast",
 	}
@@ -129,9 +127,7 @@ type QuorumSpec interface {
 // ReadQC executes the Read Quorum Call on a configuration
 // of Nodes and returns the most recent value.
 func (c *Configuration) ReadQC(ctx context.Context, in *ReadRequest) (resp *ReadResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "storage.Storage.ReadQC",
 	}
@@ -153,9 +149,7 @@ func (c *Configuration) ReadQC(ctx context.Context, in *ReadRequest) (resp *Read
 // WriteQC executes the Write Quorum Call on a configuration
 // of Nodes and returns true if a majority of Nodes were updated.
 func (c *Configuration) WriteQC(ctx context.Context, in *WriteRequest) (resp *WriteResponse, err error) {
-
 	cd := gorums.QuorumCallData{
-		Manager: c.mgr.Manager,
 		Message: in,
 		Method:  "storage.Storage.WriteQC",
 	}

--- a/multicast.go
+++ b/multicast.go
@@ -11,7 +11,7 @@ import (
 func (c Configuration) Multicast(ctx context.Context, d QuorumCallData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
 
-	md := d.Manager.newCall(d.Method)
+	md := c.newCall(d.Method)
 	sentMsgs := 0
 	send := func() {
 		for _, n := range c {
@@ -32,7 +32,7 @@ func (c Configuration) Multicast(ctx context.Context, d QuorumCallData, opts ...
 		return // don't wait for messages to be sent
 	}
 
-	replyChan, callDone := d.Manager.newReply(md, sentMsgs)
+	replyChan, callDone := c.newReply(md, sentMsgs)
 	send()
 
 	// nodeStream sends an empty reply on replyChan when the message has been sent

--- a/multicast.go
+++ b/multicast.go
@@ -8,13 +8,13 @@ import (
 // By default this function returns once the message has been sent to all nodes.
 // Providing the call option WithNoSendWaiting, the function may return
 // before the message has been sent.
-func Multicast(ctx context.Context, d QuorumCallData, opts ...CallOption) {
+func (c Configuration) Multicast(ctx context.Context, d QuorumCallData, opts ...CallOption) {
 	o := getCallOptions(E_Multicast, opts)
 
 	md := d.Manager.newCall(d.Method)
 	sentMsgs := 0
 	send := func() {
-		for _, n := range d.Nodes {
+		for _, n := range c {
 			msg := d.Message
 			if d.PerNodeArgFn != nil {
 				msg = d.PerNodeArgFn(d.Message, n.id)

--- a/quorumcall.go
+++ b/quorumcall.go
@@ -11,20 +11,19 @@ import (
 // supported by Gorums.
 type QuorumCallData struct {
 	Manager        *Manager
-	Nodes          []*Node
 	Message        protoreflect.ProtoMessage
 	Method         string
 	PerNodeArgFn   func(protoreflect.ProtoMessage, uint32) protoreflect.ProtoMessage
 	QuorumFunction func(protoreflect.ProtoMessage, map[uint32]protoreflect.ProtoMessage) (protoreflect.ProtoMessage, bool)
 }
 
-func QuorumCall(ctx context.Context, d QuorumCallData) (resp protoreflect.ProtoMessage, err error) {
-	expectedReplies := len(d.Nodes)
+func (c Configuration) QuorumCall(ctx context.Context, d QuorumCallData) (resp protoreflect.ProtoMessage, err error) {
+	expectedReplies := len(c)
 	md := d.Manager.newCall(d.Method)
 	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
 	defer callDone()
 
-	for _, n := range d.Nodes {
+	for _, n := range c {
 		msg := d.Message
 		if d.PerNodeArgFn != nil {
 			msg = d.PerNodeArgFn(d.Message, n.id)

--- a/quorumcall.go
+++ b/quorumcall.go
@@ -10,7 +10,6 @@ import (
 // and other information necessary to perform the various quorum call types
 // supported by Gorums.
 type QuorumCallData struct {
-	Manager        *Manager
 	Message        protoreflect.ProtoMessage
 	Method         string
 	PerNodeArgFn   func(protoreflect.ProtoMessage, uint32) protoreflect.ProtoMessage
@@ -19,8 +18,8 @@ type QuorumCallData struct {
 
 func (c Configuration) QuorumCall(ctx context.Context, d QuorumCallData) (resp protoreflect.ProtoMessage, err error) {
 	expectedReplies := len(c)
-	md := d.Manager.newCall(d.Method)
-	replyChan, callDone := d.Manager.newReply(md, expectedReplies)
+	md := c.newCall(d.Method)
+	replyChan, callDone := c.newReply(md, expectedReplies)
 	defer callDone()
 
 	for _, n := range c {

--- a/rpc.go
+++ b/rpc.go
@@ -7,17 +7,16 @@ import (
 )
 
 type CallData struct {
-	Node    *Node
 	Message protoreflect.ProtoMessage
 	Method  string
 }
 
-func RPCCall(ctx context.Context, d CallData) (resp protoreflect.ProtoMessage, err error) {
-	md := d.Node.newCall(d.Method)
-	replyChan, callDone := d.Node.newReply(md, 1)
+func (n *Node) RPCCall(ctx context.Context, d CallData) (resp protoreflect.ProtoMessage, err error) {
+	md := n.newCall(d.Method)
+	replyChan, callDone := n.newReply(md, 1)
 	defer callDone()
 
-	d.Node.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}}
+	n.sendQ <- gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}}
 
 	select {
 	case r := <-replyChan:

--- a/unicast.go
+++ b/unicast.go
@@ -8,20 +8,20 @@ import (
 // By default this function returns once the message has been sent.
 // Providing the call option WithNoSendWaiting, the function may return
 // before the message has been sent.
-func Unicast(ctx context.Context, d CallData, opts ...CallOption) {
+func (n *Node) Unicast(ctx context.Context, d CallData, opts ...CallOption) {
 	o := getCallOptions(E_Unicast, opts)
 
-	md := d.Node.newCall(d.Method)
+	md := n.newCall(d.Method)
 	req := gorumsStreamRequest{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}, opts: o}
 
 	if o.noSendWaiting {
-		d.Node.sendQ <- req
+		n.sendQ <- req
 		return // don't wait for message to be sent
 	}
 
 	// newReply must be called before adding req to sendQ
-	replyChan, callDone := d.Node.newReply(md, 1)
-	d.Node.sendQ <- req
+	replyChan, callDone := n.newReply(md, 1)
+	n.sendQ <- req
 	// nodeStream sends an empty reply on replyChan when the message has been sent
 	// wait until the message has been sent
 	<-replyChan


### PR DESCRIPTION
This PR makes call types be methods on gorums.Configuration and gorums.Node, and adds receiveQueue methods newCall and newReply to the Configuration type, so that these are accessible from call type implementations, avoiding the need to pass the Manager and Node fields in the CallData and QuorumCallData struct types.

Fixes #117.
