### PR TITLE
Use ctx.Err as reason in QuorumCallError

### DIFF
--- a/async.go
+++ b/async.go
@@ -72,7 +72,7 @@ func (c Configuration) AsyncCall(ctx context.Context, d QuorumCallData) *Async {
 					return
 				}
 			case <-ctx.Done():
-				fut.reply, fut.err = resp, QuorumCallError{"incomplete call", len(replies), errs}
+				fut.reply, fut.err = resp, QuorumCallError{ctx.Err().Error(), len(replies), errs}
 				return
 			}
 			if len(errs)+len(replies) == expectedReplies {

--- a/correctable.go
+++ b/correctable.go
@@ -130,7 +130,7 @@ func (c Configuration) CorrectableCall(ctx context.Context, d CorrectableCallDat
 					}
 				}
 			case <-ctx.Done():
-				corr.set(resp, clevel, QuorumCallError{"incomplete call", len(replies), errs}, true)
+				corr.set(resp, clevel, QuorumCallError{ctx.Err().Error(), len(replies), errs}, true)
 				return
 			}
 			if (d.ServerStream && len(errs) == expectedReplies) || (!d.ServerStream && len(errs)+len(replies) == expectedReplies) {

--- a/quorumcall.go
+++ b/quorumcall.go
@@ -52,7 +52,7 @@ func (c Configuration) QuorumCall(ctx context.Context, d QuorumCallData) (resp p
 				return resp, nil
 			}
 		case <-ctx.Done():
-			return resp, QuorumCallError{"incomplete call", len(replies), errs}
+			return resp, QuorumCallError{ctx.Err().Error(), len(replies), errs}
 		}
 		if len(errs)+len(replies) == expectedReplies {
 			return resp, QuorumCallError{"incomplete call", len(replies), errs}


### PR DESCRIPTION
This restores the old behavior, which allows us to detect and handle errors that are due to context cancellation.