### PR TITLE
protoc-gen-gorums prints to stdout instead of stderr

### DIFF
--- a/cmd/protoc-gen-gorums/gengorums/gorums.go
+++ b/cmd/protoc-gen-gorums/gengorums/gorums.go
@@ -4,7 +4,6 @@ package gengorums
 import (
 	"fmt"
 	"log"
-	"os"
 	"sort"
 	"strings"
 
@@ -143,7 +142,6 @@ func genGorumsMethods(gorumsType string, data servicesData, callTypeInfo *callTy
 			}
 			callType := callTypeInfo.deriveCallType(method)
 			if callType.check(method) {
-				fmt.Fprintf(os.Stderr, "generating(%v): %s\n", gorumsType, method.GoName)
 				g.P(mustExecute(parseTemplate(gorumsType, callType.template), methodData{g, method}))
 			}
 		}

--- a/cmd/protoc-gen-gorums/gengorums/gorums_bundle.go
+++ b/cmd/protoc-gen-gorums/gengorums/gorums_bundle.go
@@ -52,9 +52,9 @@ func GenerateBundleFile(dst string) {
 		log.Fatal(err)
 	}
 	if diff := cmp.Diff(currentContent, staticContent); diff != "" {
-		fmt.Fprintf(os.Stderr, "change detected (-current +new):\n%s", diff)
-		fmt.Fprintf(os.Stderr, "\nReview changes above; to revert use:\n")
-		fmt.Fprintf(os.Stderr, "mv %s.bak %s\n", dst, dst)
+		fmt.Printf("change detected (-current +new):\n%s", diff)
+		fmt.Printf("\nReview changes above; to revert use:\n")
+		fmt.Printf("mv %s.bak %s\n", dst, dst)
 	}
 	err = os.WriteFile(dst, []byte(staticContent), 0666)
 	if err != nil {

--- a/cmd/protoc-gen-gorums/main.go
+++ b/cmd/protoc-gen-gorums/main.go
@@ -13,21 +13,30 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 )
 
-const bundleLen = len("--bundle=")
+const (
+	bundleLen       = len("--bundle=")
+	genGorumsDocURL = "https://github.com/relab/gorums/blob/master/doc/user-guide.md"
+	genGoDocURL     = "https://developers.google.com/protocol-buffers/docs/reference/go-generated"
+)
 
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		fmt.Fprintf(os.Stderr, "%v %v\n", filepath.Base(os.Args[0]), version.String())
+		fmt.Printf("%v %v\n", filepath.Base(os.Args[0]), version.String())
+		os.Exit(0)
+	}
+	if len(os.Args) == 2 && os.Args[1] == "--help" {
+		fmt.Printf("See %s for usage information.\n", genGorumsDocURL)
+		fmt.Printf("See %s for information about protobuf.\n", genGoDocURL)
 		os.Exit(0)
 	}
 	if len(os.Args) == 2 && strings.HasPrefix(os.Args[1], "--bundle=") {
 		bundle := os.Args[1][bundleLen:]
 		if bundle != "" {
-			fmt.Fprintf(os.Stderr, "Generating bundle file: %s\n", bundle)
+			fmt.Printf("Generating bundle file: %s\n", bundle)
 			gengorums.GenerateBundleFile(bundle)
 			os.Exit(0)
 		}
-		fmt.Fprintf(os.Stderr, "%v --bundle flag cannot be empty\n", filepath.Base(os.Args[0]))
+		fmt.Printf("%v --bundle flag cannot be empty\n", filepath.Base(os.Args[0]))
 		os.Exit(1)
 	}
 
@@ -44,7 +53,6 @@ func main() {
 			if f.Generate {
 				switch {
 				case *dev:
-					fmt.Fprintf(os.Stderr, "Generating development files in dev folder\n")
 					gengorums.GenerateDevFiles(gen, f)
 				default:
 					gengorums.GenerateFile(gen, f)


### PR DESCRIPTION
This cleans up the printing to stderr, and instead prints to stdout,
following recent changes in protoc-gen-go. Further, it adds --help
to direct users to the web page, if wondering why they installed the
protoc-gen-gorums command. This also removes some debug printing
when generating _gorums.pb.go files; now it is silent, similar to
protoc-gen-go. It does still print Generating bundle file though,
and diff results, if the template_static.go changed.

Note that in general we should not print info to stdout during code
generation; if debug output is needed, that should be sent to stderr.
However, for the scenarios we use stdout here, we always do os.Exit(),
in which case it is fine (and seemingly preferred).
