### PR TITLE
Upgrade grpc dependency and fix deprecated grpc.WithInsecure calls

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/benchmark"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type regexpFlag struct {
@@ -189,7 +190,10 @@ func main() {
 	}
 
 	mgrOpts := []gorums.ManagerOption{
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 		gorums.WithDialTimeout(10 * time.Second),
 		gorums.WithSendBufferSize(*sendBuffer),
 	}

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -223,6 +223,7 @@ import (
   "time"
 
   "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func ExampleStorageClient() {
@@ -230,7 +231,7 @@ func ExampleStorageClient() {
     gorums.WithDialTimeout(500*time.Millisecond),
     gorums.WithGrpcDialOptions(
       grpc.WithBlock(),
-      grpc.WithInsecure(),
+      grpc.WithTransportCredentials(insecure.NewCredentials()),
     ),
   )
 ```
@@ -405,8 +406,9 @@ func ExampleStorageClient() {
     gorums.WithDialTimeout(50*time.Millisecond),
     gorums.WithGrpcDialOptions(
       grpc.WithBlock(),
-      grpc.WithInsecure(),
-  ))
+      grpc.WithTransportCredentials(insecure.NewCredentials()),
+    ),
+  )
   // Create a configuration including all nodes
   allNodesConfig, err := mgr.NewConfiguration(
     &QSpec{2},

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -128,8 +128,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa h1:I0YcKz0I7OAhddo7ya8kMnvprhcWM045PmkBdMO9zN0=
-google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562 h1:sZWkpp+mMCIr/XzilKM5CjCxqe2o7SyJ+kz097OkcNM=
+google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -139,8 +139,8 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/examples/storage/client.go
+++ b/examples/storage/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/examples/storage/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func runClient(addresses []string) {
@@ -18,8 +19,8 @@ func runClient(addresses []string) {
 	mgr := proto.NewManager(
 		gorums.WithDialTimeout(1*time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithInsecure(), // disable TLS
-			grpc.WithBlock(),    // block until connections are made
+			grpc.WithBlock(), // block until connections are made
+			grpc.WithTransportCredentials(insecure.NewCredentials()), // disable TLS
 		),
 	)
 	// create configuration containing all nodes

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/tools v0.1.8
-	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
+	google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562
 	google.golang.org/grpc v1.43.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa h1:I0YcKz0I7OAhddo7ya8kMnvprhcWM045PmkBdMO9zN0=
-google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562 h1:sZWkpp+mMCIr/XzilKM5CjCxqe2o7SyJ+kz097OkcNM=
+google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -135,8 +135,8 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/mgr_test.go
+++ b/mgr_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/tests/dummy"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -73,7 +74,10 @@ func TestManagerAddNodeWithConn(t *testing.T) {
 	defer teardown()
 	mgr := gorums.NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
-		gorums.WithGrpcDialOptions(grpc.WithInsecure(), grpc.WithBlock()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	defer mgr.Close()
 

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	gorums "github.com/relab/gorums"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type (
@@ -86,7 +87,10 @@ func TestConfig(t *testing.T) {
 	}
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	c1, teardown1 := setup(t, mgr, 4)
 	defer teardown1()

--- a/tests/correctable/correctable_test.go
+++ b/tests/correctable/correctable_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // run a test on a correctable call.
@@ -21,9 +22,13 @@ func run(t *testing.T, n int, div int, corr func(context.Context, *Configuration
 	})
 	defer teardown()
 
-	mgr := NewManager(gorums.WithDialTimeout(time.Second), gorums.WithGrpcDialOptions(
-		grpc.WithInsecure(), grpc.WithBlock(),
-	))
+	mgr := NewManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
 
 	cfg, err := mgr.NewConfiguration(qspec{div, n}, gorums.WithNodeList(addrs))
 	if err != nil {

--- a/tests/metadata/metadata_test.go
+++ b/tests/metadata/metadata_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -60,8 +61,11 @@ func TestMetadata(t *testing.T) {
 
 	mgr := NewManager(
 		gorums.WithMetadata(md),
-		gorums.WithDialTimeout(1*time.Second),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
@@ -91,8 +95,11 @@ func TestPerNodeMetadata(t *testing.T) {
 
 	mgr := NewManager(
 		gorums.WithPerNodeMetadata(perNodeMD),
-		gorums.WithDialTimeout(1*time.Second),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
@@ -116,8 +123,11 @@ func TestCanGetPeerInfo(t *testing.T) {
 	defer teardown()
 
 	mgr := NewManager(
-		gorums.WithDialTimeout(1*time.Second),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {

--- a/tests/oneway/oneway_test.go
+++ b/tests/oneway/oneway_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/tests/oneway"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type onewaySrv struct {
@@ -63,7 +64,10 @@ func setup(t testing.TB, cfgSize int) (cfg *oneway.Configuration, srvs []*oneway
 
 	mgr := oneway.NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	cfg, err := mgr.NewConfiguration(&testQSpec{}, gorums.WithNodeMap(nodeMap))
 	if err != nil {

--- a/tests/ordering/order_test.go
+++ b/tests/ordering/order_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/internal/leakcheck"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type testSrv struct {
@@ -86,7 +87,10 @@ func setup(t *testing.T, cfgSize int) (cfg *Configuration, teardown func()) {
 	})
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
-		gorums.WithGrpcDialOptions(grpc.WithBlock(), grpc.WithInsecure()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	cfg, err := mgr.NewConfiguration(&testQSpec{cfgSize}, gorums.WithNodeList(addrs))
 	if err != nil {

--- a/tests/qf/qf_test.go
+++ b/tests/qf/qf_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const requestValue = 0x1001_1001
@@ -195,8 +196,10 @@ func BenchmarkFullStackQF(b *testing.B) {
 			return srv
 		})
 		mgr := NewManager(
-			gorums.WithGrpcDialOptions(grpc.WithInsecure()),
 			gorums.WithDialTimeout(10*time.Second),
+			gorums.WithGrpcDialOptions(
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			),
 		)
 		c, err := mgr.NewConfiguration(
 			&testQSpec{quorum: n / 2},

--- a/tests/unresponsive/unreponsive_test.go
+++ b/tests/unresponsive/unreponsive_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type testSrv struct{}
@@ -29,7 +30,10 @@ func TestUnresponsive(t *testing.T) {
 
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
-		gorums.WithGrpcDialOptions(grpc.WithInsecure(), grpc.WithBlock()),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
 	)
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {


### PR DESCRIPTION
- Upgraded to protoc-gen-go-grpc v1.2.0
- Replace deprecated grpc.WithInsecure() with new API

Fixes #151.

