### PR TITLE
server: add a ConnectCallback option

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package gorums_test
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -15,7 +16,11 @@ func TestServerCallback(t *testing.T) {
 	var message string
 	signal := make(chan struct{})
 
-	srv := gorums.NewServer(gorums.WithConnectCallback(func(m metadata.MD) {
+	srv := gorums.NewServer(gorums.WithConnectCallback(func(ctx context.Context) {
+		m, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return
+		}
 		message = m.Get("message")[0]
 		signal <- struct{}{}
 	}))

--- a/server_test.go
+++ b/server_test.go
@@ -50,8 +50,7 @@ func TestServerCallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = mgr.AddNode(node)
-	if err != nil {
+	if err = mgr.AddNode(node); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,61 @@
+package gorums_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/relab/gorums"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestServerCallback(t *testing.T) {
+	var message string
+	signal := make(chan struct{})
+
+	srv := gorums.NewServer(gorums.WithConnectCallback(func(m metadata.MD) {
+		message = m.Get("message")[0]
+		signal <- struct{}{}
+	}))
+
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	md := metadata.New(map[string]string{"message": "hello"})
+
+	mgr := gorums.NewRawManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithMetadata(md),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	defer mgr.Close()
+
+	node, err := gorums.NewRawNode(lis.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = mgr.AddNode(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case <-signal:
+	}
+
+	if message != "hello" {
+		t.Errorf("incorrect message: got '%s', want 'hello'", message)
+	}
+}


### PR DESCRIPTION
This option makes it possible to add a callback function that is called whenever a node connects or reconnects to the server. This thus makes it possible to inspect the node's metadata before it sends any RPCs.