### PR TITLE
fix: node RPCCall returns nil instead of error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cmd/benchmark/benchmark
 ideas.txt
 
 cmd/protoc-gen-gorums/gengorums/template_static.go.bak
+
+# jetbrains IDE files
+.idea/

--- a/.vscode/gorums.txt
+++ b/.vscode/gorums.txt
@@ -30,6 +30,7 @@ grpc
 Hein
 ICDCS
 Idxs
+Iface
 Ingve
 installgorums
 Jehl
@@ -50,6 +51,7 @@ protobuf
 protoc
 protogen
 protoimpl
+protoreflect
 ptypes
 QCQF
 qcresult

--- a/rpc.go
+++ b/rpc.go
@@ -18,7 +18,7 @@ type CallData struct {
 // RPCCall executes a remote procedure call on the node.
 //
 // This method should be used by generated code only.
-func (n *RawNode) RPCCall(ctx context.Context, d CallData) (resp protoreflect.ProtoMessage, err error) {
+func (n *RawNode) RPCCall(ctx context.Context, d CallData) (protoreflect.ProtoMessage, error) {
 	md := &ordering.Metadata{MessageID: n.mgr.getMsgID(), Method: d.Method}
 	replyChan := make(chan response, 1)
 	n.channel.enqueue(request{ctx: ctx, msg: &Message{Metadata: md, Message: d.Message}}, replyChan, false)
@@ -26,10 +26,10 @@ func (n *RawNode) RPCCall(ctx context.Context, d CallData) (resp protoreflect.Pr
 	select {
 	case r := <-replyChan:
 		if r.err != nil {
-			return nil, err
+			return nil, r.err
 		}
 		return r.msg, nil
 	case <-ctx.Done():
-		return resp, ctx.Err()
+		return nil, ctx.Err()
 	}
 }

--- a/rpc.go
+++ b/rpc.go
@@ -25,10 +25,7 @@ func (n *RawNode) RPCCall(ctx context.Context, d CallData) (protoreflect.ProtoMe
 
 	select {
 	case r := <-replyChan:
-		if r.err != nil {
-			return nil, r.err
-		}
-		return r.msg, nil
+		return r.msg, r.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -18,7 +18,7 @@ func TestRPCCallSuccess(t *testing.T) {
 	})
 	defer teardown()
 
-	mgr := rpcTestMgr()
+	mgr := gorumsTestMgr()
 
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
@@ -44,7 +44,7 @@ func TestRPCCallDownedNode(t *testing.T) {
 	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
 		return initServer()
 	})
-	mgr := rpcTestMgr()
+	mgr := gorumsTestMgr()
 
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
@@ -74,7 +74,7 @@ func TestRPCCallTimedOut(t *testing.T) {
 	})
 	defer teardown()
 
-	mgr := rpcTestMgr()
+	mgr := gorumsTestMgr()
 
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
@@ -103,7 +103,7 @@ func initServer() *gorums.Server {
 	return srv
 }
 
-func rpcTestMgr() *dummy.Manager {
+func gorumsTestMgr() *dummy.Manager {
 	mgr := dummy.NewManager(
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -18,13 +18,8 @@ func TestRPCCallSuccess(t *testing.T) {
 	})
 	defer teardown()
 
-	mgr := dummy.NewManager(
-		gorums.WithDialTimeout(time.Second),
-		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		),
-	)
+	mgr := rpcTestMgr()
+
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
 		t.Fatal(err)
@@ -49,14 +44,8 @@ func TestRPCCallDownedNode(t *testing.T) {
 	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
 		return initServer()
 	})
+	mgr := rpcTestMgr()
 
-	mgr := dummy.NewManager(
-		gorums.WithDialTimeout(time.Second),
-		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		),
-	)
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
 		t.Fatal(err)
@@ -85,13 +74,8 @@ func TestRPCCallTimedOut(t *testing.T) {
 	})
 	defer teardown()
 
-	mgr := dummy.NewManager(
-		gorums.WithDialTimeout(time.Second),
-		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		),
-	)
+	mgr := rpcTestMgr()
+
 	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +90,7 @@ func TestRPCCallTimedOut(t *testing.T) {
 		Method:  "dummy.Dummy.Test",
 	})
 	if err == nil {
-		t.Fatalf("Unexpected error, got: %v, want: %v", err, "context deadline exceeded error")
+		t.Fatalf("Unexpected error, got: %v, want: %v", err, fmt.Errorf("context deadline exceeded"))
 	}
 	if response != nil {
 		t.Fatalf("Unexpected response, got: %v, want: %v", response, nil)
@@ -117,6 +101,17 @@ func initServer() *gorums.Server {
 	srv := gorums.NewServer()
 	dummy.RegisterDummyServer(srv, &testSrv{})
 	return srv
+}
+
+func rpcTestMgr() *dummy.Manager {
+	mgr := dummy.NewManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	return mgr
 }
 
 type testSrv struct{}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,0 +1,12 @@
+package gorums_test
+
+import (
+	"testing"
+)
+
+func TestRPCCall(t *testing.T) {
+	// TODO implement test for RPCCall
+	if true == false {
+		t.Errorf("should be true")
+	}
+}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,12 +1,126 @@
 package gorums_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/relab/gorums"
+	"github.com/relab/gorums/tests/dummy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-func TestRPCCall(t *testing.T) {
-	// TODO implement test for RPCCall
-	if true == false {
-		t.Errorf("should be true")
+func TestRPCCallSuccess(t *testing.T) {
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
+		return initServer()
+	})
+	defer teardown()
+
+	mgr := dummy.NewManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	node := mgr.Nodes()[0]
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	response, err := node.RPCCall(ctx, gorums.CallData{
+		Message: &dummy.Empty{},
+		Method:  "dummy.Dummy.Test",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error, got: %v, want: %v", err, nil)
+	}
+	if response == nil {
+		t.Fatalf("Unexpected response, got: %v, want: %v", nil, &dummy.Empty{})
+	}
+}
+
+func TestRPCCallDownedNode(t *testing.T) {
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
+		return initServer()
+	})
+
+	mgr := dummy.NewManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	teardown()                         // stop all servers on purpose
+	time.Sleep(300 * time.Millisecond) // servers are not stopped immediately
+	node := mgr.Nodes()[0]
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	response, err := node.RPCCall(ctx, gorums.CallData{
+		Message: &dummy.Empty{},
+		Method:  "dummy.Dummy.Test",
+	})
+	if err == nil {
+		t.Fatalf("Unexpected error, got: %v, want: %v", err, fmt.Errorf("rpc error: code = Unavailable desc = stream is down"))
+	}
+	if response != nil {
+		t.Fatalf("Unexpected response, got: %v, want: %v", response, nil)
+	}
+}
+
+func TestRPCCallTimedOut(t *testing.T) {
+	addrs, teardown := gorums.TestSetup(t, 1, func(_ int) gorums.ServerIface {
+		return initServer()
+	})
+	defer teardown()
+
+	mgr := dummy.NewManager(
+		gorums.WithDialTimeout(time.Second),
+		gorums.WithGrpcDialOptions(
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+	)
+	_, err := mgr.NewConfiguration(gorums.WithNodeList(addrs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node := mgr.Nodes()[0]
+	ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
+	time.Sleep(50 * time.Millisecond)
+	defer cancel()
+	response, err := node.RPCCall(ctx, gorums.CallData{
+		Message: &dummy.Empty{},
+		Method:  "dummy.Dummy.Test",
+	})
+	if err == nil {
+		t.Fatalf("Unexpected error, got: %v, want: %v", err, "context deadline exceeded error")
+	}
+	if response != nil {
+		t.Fatalf("Unexpected response, got: %v, want: %v", response, nil)
+	}
+}
+
+func initServer() *gorums.Server {
+	srv := gorums.NewServer()
+	dummy.RegisterDummyServer(srv, &testSrv{})
+	return srv
+}
+
+type testSrv struct{}
+
+func (t testSrv) Test(ctx gorums.ServerCtx, request *dummy.Empty) (response *dummy.Empty, err error) {
+	return &dummy.Empty{}, nil
 }


### PR DESCRIPTION
Fixed a bug where an error was not returned from node.RPCCall
Added tests for all return paths in RPCCall function. 