### PR TITLE
ci: Update GitHub Actions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,30 +9,39 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: ["1.21"]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
+
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
+    - name: Cache Go Modules
+      uses: actions/cache@v3
       with:
-        go-version: ${{ matrix.go-version }}
-    - name: Install Protoc
-      uses: arduino/setup-protoc@master
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
+        path: |
+          ~/.cache/go-build          # ubuntu-latest
+          ~/Library/Caches/go-build  # macos-latest
+          ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install tools
       run: |
         make tools
         make installgorums
-    - name: Test
+
+    - name: Run Tests
       run: make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,49 +1,51 @@
 name: golangci-lint
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
 
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go-version: [1.17]
+    name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v2
+      - name: Cache Go Modules
+        uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/go-build          # ubuntu-latest
+            ~/Library/Caches/go-build  # macos-latest
             ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.go-version }}-go-
+            ${{ runner.os }}-go-
 
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
+
+      - name: Setup Protoc
+        uses: arduino/setup-protoc@v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Make
         run: make
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          skip-go-installation: true
           skip-pkg-cache: true
           skip-build-cache: true
-          args: --disable errcheck
+          args: --timeout 5m --disable errcheck
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true


### PR DESCRIPTION
This updates the GitHub workflows to newer versions of the
different GitHub actions, and upgraded to run on the latest
released version of Go instead of go1.17.

Fixes #168.

