### PR TITLE
Fix NoSendWaiting check in channel

### DIFF
--- a/multicast.go
+++ b/multicast.go
@@ -38,8 +38,7 @@ func (c RawConfiguration) Multicast(ctx context.Context, d QuorumCallData, opts 
 
 	// nodeStream sends an empty reply on replyChan when the message has been sent
 	// wait until the message has been sent
-	for sentMsgs > 0 {
+	for ; sentMsgs > 0; sentMsgs-- {
 		<-replyChan
-		sentMsgs--
 	}
 }

--- a/tests/oneway/oneway_test.go
+++ b/tests/oneway/oneway_test.go
@@ -232,17 +232,18 @@ func BenchmarkUnicast(b *testing.B) {
 	for _, srv := range srvs {
 		srv.benchmark = true
 	}
+	node := cfg.Nodes()[0]
 	in := &oneway.Request{Num: 0}
 	b.Run("UnicastSendWaiting__", func(b *testing.B) {
 		for c := 1; c <= b.N; c++ {
 			in.Num = uint64(c)
-			cfg.Nodes()[0].Unicast(context.Background(), in)
+			node.Unicast(context.Background(), in)
 		}
 	})
 	b.Run("UnicastNoSendWaiting", func(b *testing.B) {
 		for c := 1; c <= b.N; c++ {
 			in.Num = uint64(c)
-			cfg.Nodes()[0].Unicast(context.Background(), in, gorums.WithNoSendWaiting())
+			node.Unicast(context.Background(), in, gorums.WithNoSendWaiting())
 		}
 	})
 	teardown()
@@ -263,7 +264,7 @@ func BenchmarkMulticast(b *testing.B) {
 	b.Run("MulticastNoSendWaiting", func(b *testing.B) {
 		for c := 1; c <= b.N; c++ {
 			in.Num = uint64(c)
-			cfg.Nodes()[0].Unicast(context.Background(), in, gorums.WithNoSendWaiting())
+			cfg.Multicast(context.Background(), in, gorums.WithNoSendWaiting())
 		}
 	})
 	teardown()


### PR DESCRIPTION
This fixes an issue with the logic (channel.go) that unblocks the response channel for the case when NoSendWaiting is not enabled; in this case we send an empty response to unblock the calling call type (unicast or multicast) and clean up the responseRouters map. This also adds more detailed comments to better explain what's going on.

Fixes #187

