### PR TITLE
Fix goroutine leak when test with an empty node list

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -44,8 +44,9 @@ func TestChannelCreation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	//the node should be closed manually because it isn't added to the configuration
+	defer node.close()
 	mgr := dummyMgr()
-	defer mgr.Close()
 	// a proper connection should NOT be established here
 	node.connect(mgr)
 
@@ -117,8 +118,9 @@ func TestChannelReconnection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	//the node should be closed manually because it isn't added to the configuration
+	defer node.close()
 	mgr := dummyMgr()
-	defer mgr.Close()
 	// a proper connection should NOT be established here because server is not started
 	node.connect(mgr)
 


### PR DESCRIPTION
Node isn't added to configuration in these test cases. So n.cancel() can't be called to awaken the <-c.parentCtx.Done(), which results in goroutines leak. So the node should be closed manually to avoid goroutines leak. 