### PR TITLE
Remove deprecated grpc methods

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -106,7 +106,7 @@ func TestChannelUnsuccessfulConnection(t *testing.T) {
 		t.Fatal("the node was not added to the configuration")
 	}
 	if node.conn == nil {
-		t.Fatal("connection should not be nil when NOT using WithBlock()")
+		t.Fatal("connection should not be nil")
 	}
 }
 

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -191,7 +191,6 @@ func main() {
 
 	mgrOpts := []gorums.ManagerOption{
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 		gorums.WithDialTimeout(10 * time.Second),

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -193,7 +193,6 @@ func main() {
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
-		gorums.WithDialTimeout(10 * time.Second),
 		gorums.WithSendBufferSize(*sendBuffer),
 	}
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -221,7 +221,6 @@ package gorumsexample
 
 import (
   "log"
-  "time"
 
   "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -231,7 +231,6 @@ func ExampleStorageClient() {
   mgr := NewManager(
     gorums.WithDialTimeout(500*time.Millisecond),
     gorums.WithGrpcDialOptions(
-      grpc.WithBlock(),
       grpc.WithTransportCredentials(insecure.NewCredentials()),
     ),
   )
@@ -406,7 +405,6 @@ func ExampleStorageClient() {
   mgr := NewManager(
     gorums.WithDialTimeout(50*time.Millisecond),
     gorums.WithGrpcDialOptions(
-      grpc.WithBlock(),
       grpc.WithTransportCredentials(insecure.NewCredentials()),
     ),
   )

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -229,7 +229,6 @@ import (
 
 func ExampleStorageClient() {
   mgr := NewManager(
-    gorums.WithDialTimeout(500*time.Millisecond),
     gorums.WithGrpcDialOptions(
       grpc.WithTransportCredentials(insecure.NewCredentials()),
     ),
@@ -403,7 +402,6 @@ func ExampleStorageClient() {
   }
 
   mgr := NewManager(
-    gorums.WithDialTimeout(50*time.Millisecond),
     gorums.WithGrpcDialOptions(
       grpc.WithTransportCredentials(insecure.NewCredentials()),
     ),

--- a/examples/storage/client.go
+++ b/examples/storage/client.go
@@ -19,7 +19,6 @@ func runClient(addresses []string) {
 	mgr := proto.NewManager(
 		gorums.WithDialTimeout(1*time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(), // block until connections are made
 			grpc.WithTransportCredentials(insecure.NewCredentials()), // disable TLS
 		),
 	)

--- a/examples/storage/client.go
+++ b/examples/storage/client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/examples/storage/proto"
@@ -17,7 +16,6 @@ func runClient(addresses []string) {
 
 	// init gorums manager
 	mgr := proto.NewManager(
-		gorums.WithDialTimeout(1*time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()), // disable TLS
 		),

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,12 @@ require (
 	golang.org/x/sync v0.6.0
 	golang.org/x/tools v0.19.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237
-	google.golang.org/grpc v1.62.1
+	google.golang.org/grpc v1.63.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.33.0
 )
 
 require (
-	github.com/golang/protobuf v1.5.4 // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
@@ -16,8 +14,8 @@ golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
-google.golang.org/grpc v1.62.1 h1:B4n+nfKzOICUXMgyrNd19h/I9oH0L1pizfk1d4zSgTk=
-google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
+google.golang.org/grpc v1.63.0 h1:WjKe+dnvABXyPJMD7KDNLxtoGk5tgk+YFWN6cBWjZE8=
+google.golang.org/grpc v1.63.0/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=

--- a/mgr_test.go
+++ b/mgr_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"log"
 	"testing"
-	"time"
 
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/tests/dummy"
@@ -73,7 +72,6 @@ func TestManagerAddNodeWithConn(t *testing.T) {
 	})
 	defer teardown()
 	mgr := gorums.NewRawManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/mgr_test.go
+++ b/mgr_test.go
@@ -75,7 +75,6 @@ func TestManagerAddNodeWithConn(t *testing.T) {
 	mgr := gorums.NewRawManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/node.go
+++ b/node.go
@@ -78,9 +78,7 @@ func (n *RawNode) dial() error {
 		n.conn.Close()
 	}
 	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), n.mgr.opts.nodeDialTimeout)
-	defer cancel()
-	n.conn, err = grpc.DialContext(ctx, n.addr, n.mgr.opts.grpcDialOpts...)
+	n.conn, err = grpc.NewClient(n.addr, n.mgr.opts.grpcDialOpts...)
 	return err
 }
 

--- a/opts.go
+++ b/opts.go
@@ -10,21 +10,19 @@ import (
 )
 
 type managerOptions struct {
-	grpcDialOpts    []grpc.DialOption
-	nodeDialTimeout time.Duration
-	logger          *log.Logger
-	noConnect       bool
-	backoff         backoff.Config
-	sendBuffer      uint
-	metadata        metadata.MD
-	perNodeMD       func(uint32) metadata.MD
+	grpcDialOpts []grpc.DialOption
+	logger       *log.Logger
+	noConnect    bool
+	backoff      backoff.Config
+	sendBuffer   uint
+	metadata     metadata.MD
+	perNodeMD    func(uint32) metadata.MD
 }
 
 func newManagerOptions() managerOptions {
 	return managerOptions{
-		backoff:         backoff.DefaultConfig,
-		sendBuffer:      0,
-		nodeDialTimeout: 50 * time.Millisecond,
+		backoff:    backoff.DefaultConfig,
+		sendBuffer: 0,
 	}
 }
 
@@ -34,9 +32,7 @@ type ManagerOption func(*managerOptions)
 // WithDialTimeout returns a ManagerOption which is used to set the dial
 // context timeout to be used when initially connecting to each node in its pool.
 func WithDialTimeout(timeout time.Duration) ManagerOption {
-	return func(o *managerOptions) {
-		o.nodeDialTimeout = timeout
-	}
+	return func(o *managerOptions) {}
 }
 
 // WithGrpcDialOptions returns a ManagerOption which sets any gRPC dial options

--- a/opts.go
+++ b/opts.go
@@ -29,12 +29,6 @@ func newManagerOptions() managerOptions {
 // ManagerOption provides a way to set different options on a new Manager.
 type ManagerOption func(*managerOptions)
 
-// WithDialTimeout returns a ManagerOption which is used to set the dial
-// context timeout to be used when initially connecting to each node in its pool.
-func WithDialTimeout(timeout time.Duration) ManagerOption {
-	return func(o *managerOptions) {}
-}
-
 // WithGrpcDialOptions returns a ManagerOption which sets any gRPC dial options
 // the Manager should use when initially connecting to each node in its pool.
 func WithGrpcDialOptions(opts ...grpc.DialOption) ManagerOption {

--- a/opts.go
+++ b/opts.go
@@ -2,7 +2,6 @@ package gorums
 
 import (
 	"log"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -105,7 +105,6 @@ func initServer() *gorums.Server {
 
 func gorumsTestMgr() *dummy.Manager {
 	mgr := dummy.NewManager(
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -107,7 +107,6 @@ func gorumsTestMgr() *dummy.Manager {
 	mgr := dummy.NewManager(
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -39,7 +39,6 @@ func TestServerCallback(t *testing.T) {
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithMetadata(md),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -36,7 +36,6 @@ func TestServerCallback(t *testing.T) {
 	md := metadata.New(map[string]string{"message": "hello"})
 
 	mgr := gorums.NewRawManager(
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithMetadata(md),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -88,7 +88,6 @@ func TestConfig(t *testing.T) {
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	fmt "fmt"
 	"testing"
-	"time"
 
 	gorums "github.com/relab/gorums"
 	"google.golang.org/grpc"
@@ -86,7 +85,6 @@ func TestConfig(t *testing.T) {
 		}
 	}
 	mgr := NewManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/correctable/correctable_test.go
+++ b/tests/correctable/correctable_test.go
@@ -23,7 +23,6 @@ func run(t *testing.T, n int, div int, corr func(context.Context, *Configuration
 	defer teardown()
 
 	mgr := NewManager(
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/correctable/correctable_test.go
+++ b/tests/correctable/correctable_test.go
@@ -25,7 +25,6 @@ func run(t *testing.T, n int, div int, corr func(context.Context, *Configuration
 	mgr := NewManager(
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/tests/metadata/metadata_test.go
+++ b/tests/metadata/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
@@ -61,7 +60,6 @@ func TestMetadata(t *testing.T) {
 
 	mgr := NewManager(
 		gorums.WithMetadata(md),
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
@@ -94,7 +92,6 @@ func TestPerNodeMetadata(t *testing.T) {
 
 	mgr := NewManager(
 		gorums.WithPerNodeMetadata(perNodeMD),
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
@@ -121,7 +118,6 @@ func TestCanGetPeerInfo(t *testing.T) {
 	defer teardown()
 
 	mgr := NewManager(
-		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/metadata/metadata_test.go
+++ b/tests/metadata/metadata_test.go
@@ -63,7 +63,6 @@ func TestMetadata(t *testing.T) {
 		gorums.WithMetadata(md),
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)
@@ -97,7 +96,6 @@ func TestPerNodeMetadata(t *testing.T) {
 		gorums.WithPerNodeMetadata(perNodeMD),
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)
@@ -125,7 +123,6 @@ func TestCanGetPeerInfo(t *testing.T) {
 	mgr := NewManager(
 		gorums.WithDialTimeout(time.Second),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/tests/oneway/oneway_test.go
+++ b/tests/oneway/oneway_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/tests/oneway"
@@ -63,7 +62,6 @@ func setup(t testing.TB, cfgSize int) (cfg *oneway.Configuration, srvs []*oneway
 	}
 
 	mgr := oneway.NewManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/oneway/oneway_test.go
+++ b/tests/oneway/oneway_test.go
@@ -65,7 +65,6 @@ func setup(t testing.TB, cfgSize int) (cfg *oneway.Configuration, srvs []*oneway
 	mgr := oneway.NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/tests/ordering/order_test.go
+++ b/tests/ordering/order_test.go
@@ -89,7 +89,6 @@ func setup(t *testing.T, cfgSize int) (cfg *Configuration, teardown func()) {
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)

--- a/tests/ordering/order_test.go
+++ b/tests/ordering/order_test.go
@@ -87,7 +87,6 @@ func setup(t *testing.T, cfgSize int) (cfg *Configuration, teardown func()) {
 		return srv
 	})
 	mgr := NewManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/qf/qf_test.go
+++ b/tests/qf/qf_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
@@ -196,7 +195,6 @@ func BenchmarkFullStackQF(b *testing.B) {
 			return srv
 		})
 		mgr := NewManager(
-			gorums.WithDialTimeout(10*time.Second),
 			gorums.WithGrpcDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			),

--- a/tests/tls/tls_test.go
+++ b/tests/tls/tls_test.go
@@ -50,7 +50,6 @@ func TestTLS(t *testing.T) {
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, "")),
-			grpc.WithReturnConnectionError(),
 		),
 	)
 	_, err = mgr.NewConfiguration(gorums.WithNodeList(addrs))

--- a/tests/tls/tls_test.go
+++ b/tests/tls/tls_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"testing"
-	"time"
 
 	"github.com/relab/gorums"
 	"google.golang.org/grpc"
@@ -47,7 +46,6 @@ func TestTLS(t *testing.T) {
 	defer teardown()
 
 	mgr := NewManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, "")),
 		),

--- a/tests/tls/tls_test.go
+++ b/tests/tls/tls_test.go
@@ -49,7 +49,6 @@ func TestTLS(t *testing.T) {
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, "")),
 			grpc.WithReturnConnectionError(),
 		),

--- a/tests/unresponsive/unreponsive_test.go
+++ b/tests/unresponsive/unreponsive_test.go
@@ -29,7 +29,6 @@ func TestUnresponsive(t *testing.T) {
 	defer teardown()
 
 	mgr := NewManager(
-		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),

--- a/tests/unresponsive/unreponsive_test.go
+++ b/tests/unresponsive/unreponsive_test.go
@@ -31,7 +31,6 @@ func TestUnresponsive(t *testing.T) {
 	mgr := NewManager(
 		gorums.WithDialTimeout(100*time.Millisecond),
 		gorums.WithGrpcDialOptions(
-			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)


### PR DESCRIPTION
Removing deprecated grpc methods and using the new NewClient method instead of DialContext.
This also removes the gorums.WithDialTimeout method.
This means that you cannot know if the grpc server is not responding before you use any rpc call.



- **list of removed methods**
1. grpc.DialContext
2. grpc.WithBlock
3. grpc.grpc.WithReturnConnectionError

- **References**
[grpc anti-patterns](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md)

Fixes #196
