### PR TITLE
Flexible and simplified mock proto solution via TestMain

### DIFF
--- a/.vscode/gorums.txt
+++ b/.vscode/gorums.txt
@@ -97,5 +97,6 @@ unmarshaled
 unmarshaling
 unmarshals
 userguide
+wrapperspb
 Xeon
 Zorums

--- a/channel_test.go
+++ b/channel_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/relab/gorums/ordering"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	pb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const defaultTestTimeout = 3 * time.Second
@@ -34,7 +35,7 @@ func newNodeWithServer(t testing.TB, delay time.Duration) *RawNode {
 type mockSrv struct{}
 
 func (mockSrv) Test(_ ServerCtx, req proto.Message) (proto.Message, error) {
-	return mock.NewResponse(mock.GetVal(req) + "-mocked-"), nil
+	return pb.String(mock.GetVal(req) + "-mocked-"), nil
 }
 
 func newNodeWithStoppableServer(t testing.TB, delay time.Duration) (*RawNode, func()) {
@@ -42,7 +43,7 @@ func newNodeWithStoppableServer(t testing.TB, delay time.Duration) (*RawNode, fu
 	addrs, teardown := TestSetup(t, 1, func(_ int) ServerIface {
 		mockSrv := &mockSrv{}
 		srv := NewServer()
-		srv.RegisterHandler(mock.ServerMethodName, func(ctx ServerCtx, in *Message) (*Message, error) {
+		srv.RegisterHandler(mock.TestMethod, func(ctx ServerCtx, in *Message) (*Message, error) {
 			// Simulate slow processing
 			time.Sleep(delay)
 			resp, err := mockSrv.Test(ctx, in.GetProtoMessage())
@@ -59,7 +60,7 @@ func sendRequest(t testing.TB, node *RawNode, req request, msgID uint64) respons
 	if req.ctx == nil {
 		req.ctx = t.Context()
 	}
-	req.msg = NewRequestMessage(ordering.NewGorumsMetadata(req.ctx, msgID, mock.ServerMethodName), nil)
+	req.msg = NewRequestMessage(ordering.NewGorumsMetadata(req.ctx, msgID, mock.TestMethod), nil)
 	replyChan := make(chan response, 1)
 	node.channel.enqueue(req, replyChan)
 
@@ -517,7 +518,7 @@ func TestChannelDeadlock(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 			defer cancel()
 
-			md := ordering.NewGorumsMetadata(ctx, uint64(100+id), mock.ServerMethodName)
+			md := ordering.NewGorumsMetadata(ctx, uint64(100+id), mock.TestMethod)
 			req := request{ctx: ctx, msg: NewRequestMessage(md, nil)}
 
 			// try to enqueue

--- a/config_test.go
+++ b/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/internal/testutils/mock"
 	"google.golang.org/grpc/encoding"
+	pb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func init() {
@@ -226,8 +227,8 @@ func TestConfigConcurrentAccess(t *testing.T) {
 	for range 2 {
 		wg.Go(func() {
 			_, err := node.RPCCall(context.Background(), gorums.CallData{
-				Message: mock.NewRequest(""),
-				Method:  mock.ServerMethodName,
+				Message: pb.String(""),
+				Method:  mock.TestMethod,
 			})
 			if err != nil {
 				errCh <- err

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,34 @@
+package gorums
+
+import (
+	"os"
+	"testing"
+
+	"github.com/relab/gorums/internal/testutils/mock"
+	pb "google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestMain(m *testing.M) {
+	// Register the default mock services for integration tests.
+	if err := mock.RegisterServices([]mock.Service{
+		{
+			Name: "mock.MockService",
+			Methods: []mock.Method{
+				{
+					Name:   "Test",
+					Input:  &pb.StringValue{},
+					Output: &pb.StringValue{},
+				},
+				{
+					Name:   "GetValue",
+					Input:  &pb.Int32Value{},
+					Output: &pb.Int32Value{},
+				},
+			},
+		},
+	}); err != nil {
+		panic(err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/quorumcall_test.go
+++ b/quorumcall_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/internal/testutils/mock"
 	"google.golang.org/protobuf/proto"
+	pb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestQuorumCallSuccess(t *testing.T) {
@@ -17,8 +18,8 @@ func TestQuorumCallSuccess(t *testing.T) {
 	cfg := gorums.NewConfig(t, addrs)
 
 	cd := gorums.QuorumCallData{
-		Message: mock.NewRequest(""),
-		Method:  mock.ServerMethodName,
+		Message: pb.String(""),
+		Method:  mock.TestMethod,
 		QuorumFunction: func(_ proto.Message, replies map[uint32]proto.Message) (proto.Message, bool) {
 			t.Logf("Received %d replies: %v", len(replies), replies)
 			if len(replies) > 2 {
@@ -40,6 +41,6 @@ func TestQuorumCallSuccess(t *testing.T) {
 		t.Fatalf("Unexpected error, got: %v, want: %v", err, nil)
 	}
 	if response == nil {
-		t.Fatalf("Unexpected response, got: %v, want: %v", response, mock.NewResponse(""))
+		t.Fatalf("Unexpected response, got: %v, want: %v", response, pb.String(""))
 	}
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/relab/gorums"
 	"github.com/relab/gorums/internal/testutils/mock"
 	"google.golang.org/grpc/encoding"
+	pb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func init() {
@@ -26,8 +27,8 @@ func TestRPCCallSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	response, err := node.RPCCall(ctx, gorums.CallData{
-		Message: mock.NewRequest(""),
-		Method:  mock.ServerMethodName,
+		Message: pb.String(""),
+		Method:  mock.TestMethod,
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error, got: %v, want: %v", err, nil)
@@ -46,8 +47,8 @@ func TestRPCCallDownedNode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	response, err := node.RPCCall(ctx, gorums.CallData{
-		Message: mock.NewRequest(""),
-		Method:  mock.ServerMethodName,
+		Message: pb.String(""),
+		Method:  mock.TestMethod,
 	})
 	if err == nil {
 		t.Fatalf("Expected error, got: %v, want: %v", err, fmt.Errorf("rpc error: code = Unavailable desc = stream is down"))
@@ -67,8 +68,8 @@ func TestRPCCallTimedOut(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	defer cancel()
 	response, err := node.RPCCall(ctx, gorums.CallData{
-		Message: mock.NewRequest(""),
-		Method:  mock.ServerMethodName,
+		Message: pb.String(""),
+		Method:  mock.TestMethod,
 	})
 	if err == nil {
 		t.Fatalf("Expected error, got: %v, want: %v", err, fmt.Errorf("context deadline exceeded"))


### PR DESCRIPTION
This replaces use of the mock.Register() test helper function with a more flexible solution that supports wrapperspb types. The only caveat is that this requires pre-registration via TestMain, but is much more flexible, since we can add custom services, methods and message types for our testing needs without having to define them via proto files that needs to be generated.

Note: this adds mock.GetValue, which will be used in a future test.

