### PR TITLE
Fix ignore logic in TestMulticastPerNode

### DIFF
--- a/internal/tests/oneway/oneway_test.go
+++ b/internal/tests/oneway/oneway_test.go
@@ -3,6 +3,7 @@ package oneway_test
 import (
 	context "context"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 
@@ -125,15 +126,8 @@ func TestMulticastPerNode(t *testing.T) {
 	add := func(n uint64, id uint32) uint64 { return n + uint64(id) }
 
 	// makeIgnoreFunc creates a function that checks if a node ID should be ignored.
-	// It captures its own copy of the ignoreNodes slice to avoid data races.
 	makeIgnoreFunc := func(ignoreNodes []uint32) func(uint32) bool {
-		ignoreSet := make(map[uint32]bool, len(ignoreNodes))
-		for _, id := range ignoreNodes {
-			ignoreSet[id] = true
-		}
-		return func(id uint32) bool {
-			return ignoreSet[id]
-		}
+		return func(id uint32) bool { return slices.Contains(ignoreNodes, id) }
 	}
 
 	// transformation function that uses the MapRequest interceptor


### PR DESCRIPTION
Fixes #262

The test had two issues:
1. The ignore() function had a bug where the return statement inside
   the for loop would only check the first element of ignoreNodes.
2. The ignoreNodes variable was shared across test cases, creating
   potential state leakage between tests.

Refactored to use factory functions (makeIgnoreFunc, makeMapFunc) that
create test-local closures, ensuring each test case has its own isolated
ignore function and map function. Changed ignoreNodes type from []int
to []uint32 for type consistency with node IDs.

This issue was raised by deepsource earlier, but I ignored it and
I still think the test would work just fine. However, it is better
to rule out those issues so that if it fails it is not because of
the shared state issue.
