### PR TITLE
Move the NodeStream server to internal/stream

### DIFF
--- a/internal/stream/server.go
+++ b/internal/stream/server.go
@@ -1,0 +1,81 @@
+package stream
+
+import (
+	"context"
+	"sync"
+)
+
+// MessageHandler handles an incoming stream message on the server side.
+// It is called in a new goroutine for each received message.
+// The handler must eventually release the mutex (by calling mut.Unlock())
+// to allow the next request to be processed. The finished channel is used
+// to send response messages back to the client.
+type MessageHandler func(ctx context.Context, mut *sync.Mutex, finished chan<- *Message, msg *Message)
+
+// Server implements the Gorums gRPC service for handling node streams.
+type Server struct {
+	handlers        map[string]MessageHandler
+	buffer          uint
+	connectCallback func(context.Context)
+	UnimplementedGorumsServer
+}
+
+// NewServer creates a new StreamServer with the given buffer size
+// and optional connect callback.
+func NewServer(buffer uint, connectCallback func(context.Context)) *Server {
+	return &Server{
+		handlers:        make(map[string]MessageHandler),
+		buffer:          buffer,
+		connectCallback: connectCallback,
+	}
+}
+
+// RegisterHandler registers a message handler for the specified method name.
+func (s *Server) RegisterHandler(method string, handler MessageHandler) {
+	s.handlers[method] = handler
+}
+
+// NodeStream handles a connection to a single client. The stream is aborted if there
+// is any error with sending or receiving.
+func (s *Server) NodeStream(srv Gorums_NodeStreamServer) error {
+	var mut sync.Mutex
+	finished := make(chan *Message, s.buffer)
+	ctx := srv.Context()
+
+	if s.connectCallback != nil {
+		s.connectCallback(ctx)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case streamOut := <-finished:
+				if err := srv.Send(streamOut); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// Start with a locked mutex
+	mut.Lock()
+	defer mut.Unlock()
+
+	for {
+		streamIn, err := srv.Recv()
+		if err != nil {
+			return err
+		}
+		if handler, ok := s.handlers[streamIn.GetMethod()]; ok {
+			// We start the handler in a new goroutine in order to allow multiple
+			// handlers to run concurrently. However, to preserve request ordering,
+			// the handler must unlock the shared mutex when it has either finished,
+			// or when it is safe to start processing the next request.
+			go handler(ctx, &mut, finished, streamIn)
+			// Wait until the handler releases the mutex.
+			mut.Lock()
+		}
+	}
+}


### PR DESCRIPTION
## Move `NodeStream` handler to `internal/stream`

### Motivation

As part of the ongoing refactor to consolidate stream infrastructure in
`internal/stream`, this PR moves the gRPC `NodeStream` implementation out
of the top-level `gorums` package and into a new `internal/stream.Server`
type.

### Changes

**New file: `internal/stream/server.go`**

Introduces `stream.Server`, which implements the gRPC `GorumsServer`
interface. It owns the per-connection receive/send loop and mutex-based
request ordering, and dispatches each incoming message to a registered
`MessageHandler` callback:

```go
type MessageHandler func(ctx context.Context, mut *sync.Mutex, finished chan<- *Message, msg *Message)
```

The callback design decouples `NodeStream` from `gorums.Message`, keeping
the stream package free of any dependency on gorums-level types.

**Modified: `server.go`**

- Removes `streamServer`, `newStreamServer()`, and `NodeStream()`.
- `Server.srv` changes from `*streamServer` to `*stream.Server`.
- `RegisterHandler` injects a `MessageHandler` closure that handles
  `ServerCtx` creation, request unmarshaling, `gorums.Message` wrapping,
  interceptor chaining, and response dispatch.

### Design

The boundary is a callback: `internal/stream` owns the transport loop;
`gorums` owns the application-layer message handling. This preserves the
public API (`gorums.Server`, `gorums.ServerCtx`, `gorums.Interceptor`,
`gorums.Handler`, `gorums.Message`) with no changes to generated code or
user-facing types.

### Testing

All existing tests pass. The two pre-existing failures in
`TestChannelEnsureStream` and `TestChannelStreamReadyAfterReconnect` are
unrelated to this change.

Fixes #269

