### PR TITLE
Symmetric Configuration support with separate outbound and inbound channel (Phase 1)

### DIFF
--- a/node.go
+++ b/node.go
@@ -105,8 +105,8 @@ func newNode(addr string, opts nodeOptions) (*Node, error) {
 	}
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 
-	// Create channel and establish gRPC node stream
-	n.channel = stream.NewChannel(ctx, conn, n.id, opts.SendBufferSize)
+	// Create new outbound channel and establish gRPC node stream
+	n.channel = stream.NewOutboundChannel(ctx, n.id, opts.SendBufferSize, conn)
 	return n, nil
 }
 


### PR DESCRIPTION
Define BidiStream to abstract both grpc.BidiStreamingClient and
grpc.BidiStreamingServer, allowing Channel to handle both outbound
(client-initiated) and inbound (server-accepted) streams uniformly.

Key changes:
- Add BidiStream interface with Send/Recv to internal/stream
- Change Channel.stream field from Gorums_NodeStreamClient to BidiStream
- Add NewInboundChannel: creates a channel from a server-side stream;
  conn is nil, stream is pre-set, close does not touch the connection
- Rename NewChannel to NewOutboundChannel
- Refactor NewOutboundChannel and NewInboundChannel to share newChannel,
  which closes over connCancel and conn directly in closeOnceFunc
- Add IsInbound(): returns true when conn is nil
- ensureStream: inbound channels return ErrStreamDown instead of reconnecting
- isConnected: inbound channels check connCtx.Err() instead of conn state
- clearStream: guard streamCancel nil for inbound channels
- Add mockBidiStream test helper and four new tests:
  TestIsInbound (table-driven), TestInboundChannel,
  TestInboundChannelClose, TestInboundChannelStreamDown

All existing tests pass unchanged.

Fixes #273

