### PR TITLE
Replace MultiSorter with slices.SortFunc in node sorting

### DIFF
--- a/config.go
+++ b/config.go
@@ -155,7 +155,7 @@ func (c Configuration) Add(ids ...uint32) Configuration {
 			}
 		}
 	}
-	OrderedBy(ID).Sort(nodes)
+	slices.SortFunc(nodes, ID)
 	return nodes
 }
 

--- a/config_opts.go
+++ b/config_opts.go
@@ -140,7 +140,7 @@ func (b *nodeBuilder) add(id uint32, addr string) error {
 
 // configuration returns the built Configuration, sorted by ID.
 func (b *nodeBuilder) configuration() Configuration {
-	OrderedBy(ID).Sort(b.nodes)
+	slices.SortFunc(b.nodes, ID)
 	return b.nodes
 }
 

--- a/examples/storage/repl.go
+++ b/examples/storage/repl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -442,7 +443,7 @@ func (r repl) parseConfiguration(cfgStr string) (pb.Configuration, error) {
 	for _, i := range indices {
 		nodes = append(nodes, cfgNodes[i])
 	}
-	gorums.OrderedBy(gorums.ID).Sort(nodes)
+	slices.SortFunc(nodes, gorums.ID)
 	return pb.Configuration(nodes), nil
 }
 

--- a/inbound_manager.go
+++ b/inbound_manager.go
@@ -304,8 +304,8 @@ func (im *inboundManager) rebuildConfig() {
 			}
 		}
 	}
-	OrderedBy(ID).Sort(cfg)
-	OrderedBy(ID).Sort(clientCfg)
+	slices.SortFunc(cfg, ID)
+	slices.SortFunc(clientCfg, ID)
 	im.config = cfg
 	im.clientConfig = clientCfg
 	if im.onConfigChange != nil {

--- a/node.go
+++ b/node.go
@@ -269,10 +269,12 @@ var ID = func(a, b *Node) int {
 // Nodes with no error sort before nodes with an error.
 // It is compatible with [slices.SortFunc] and related helpers.
 var LastNodeError = func(a, b *Node) int {
+	aErr := a.LastErr()
+	bErr := b.LastErr()
 	switch {
-	case a.LastErr() != nil && b.LastErr() == nil:
+	case aErr != nil && bErr == nil:
 		return 1
-	case a.LastErr() == nil && b.LastErr() != nil:
+	case aErr == nil && bErr != nil:
 		return -1
 	default:
 		return 0

--- a/node.go
+++ b/node.go
@@ -1,11 +1,10 @@
 package gorums
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net"
-	"sort"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -260,85 +259,24 @@ func (n *Node) Latency() time.Duration {
 	return n.router.Latency()
 }
 
-type lessFunc func(n1, n2 *Node) bool
-
-// MultiSorter implements the Sort interface, sorting the nodes within.
-type MultiSorter struct {
-	nodes []*Node
-	less  []lessFunc
+// ID compares nodes by their identifier in increasing order.
+// It is compatible with [slices.SortFunc] and related helpers.
+var ID = func(a, b *Node) int {
+	return cmp.Compare(a.id, b.id)
 }
 
-// Sort sorts the argument slice according to the less functions passed to
-// OrderedBy.
-func (ms *MultiSorter) Sort(nodes []*Node) {
-	ms.nodes = nodes
-	sort.Sort(ms)
-}
-
-// OrderedBy returns a Sorter that sorts using the less functions, in order.
-// Call its Sort method to sort the data.
-func OrderedBy(less ...lessFunc) *MultiSorter {
-	return &MultiSorter{
-		less: less,
+// LastNodeError compares nodes by their LastErr() status.
+// Nodes with no error sort before nodes with an error.
+// It is compatible with [slices.SortFunc] and related helpers.
+var LastNodeError = func(a, b *Node) int {
+	switch {
+	case a.LastErr() != nil && b.LastErr() == nil:
+		return 1
+	case a.LastErr() == nil && b.LastErr() != nil:
+		return -1
+	default:
+		return 0
 	}
-}
-
-// Len is part of sort.Interface.
-func (ms *MultiSorter) Len() int {
-	return len(ms.nodes)
-}
-
-// Swap is part of sort.Interface.
-func (ms *MultiSorter) Swap(i, j int) {
-	ms.nodes[i], ms.nodes[j] = ms.nodes[j], ms.nodes[i]
-}
-
-// Less is part of sort.Interface. It is implemented by looping along the
-// less functions until it finds a comparison that is either Less or not
-// Less. Note that it can call the less functions twice per call. We
-// could change the functions to return -1, 0, 1 and reduce the
-// number of calls for greater efficiency: an exercise for the reader.
-func (ms *MultiSorter) Less(i, j int) bool {
-	p, q := ms.nodes[i], ms.nodes[j]
-	// Try all but the last comparison.
-	var k int
-	for k = range len(ms.less) - 1 {
-		less := ms.less[k]
-		switch {
-		case less(p, q):
-			// p < q, so we have a decision.
-			return true
-		case less(q, p):
-			// p > q, so we have a decision.
-			return false
-		}
-		// p == q; try the next comparison.
-	}
-	// All comparisons to here said "equal", so just return whatever
-	// the final comparison reports.
-	return ms.less[k](p, q)
-}
-
-// ID sorts nodes by their identifier in increasing order.
-var ID = func(n1, n2 *Node) bool {
-	return n1.id < n2.id
-}
-
-// Port sorts nodes by their port number in increasing order.
-// Warning: This function may be removed in the future.
-var Port = func(n1, n2 *Node) bool {
-	p1, _ := strconv.Atoi(n1.Port())
-	p2, _ := strconv.Atoi(n2.Port())
-	return p1 < p2
-}
-
-// LastNodeError sorts nodes by their LastErr() status in increasing order. A
-// node with LastErr() != nil is larger than a node with LastErr() == nil.
-var LastNodeError = func(n1, n2 *Node) bool {
-	if n1.LastErr() != nil && n2.LastErr() == nil {
-		return false
-	}
-	return true
 }
 
 // compile-time assertion for interface compliance.

--- a/node_test.go
+++ b/node_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,30 +21,53 @@ func TestNodeSort(t *testing.T) {
 		n.channel.Store(stream.NewChannelWithState(err))
 		return n
 	}
+	someErr := errors.New("some error")
 	nodes := []*Node{
 		makeNode(100, nil),
-		makeNode(101, errors.New("some error")),
+		makeNode(101, someErr),
 		makeNode(42, nil),
-		makeNode(99, errors.New("some error")),
+		makeNode(99, someErr),
 	}
 
-	n := len(nodes)
-
-	OrderedBy(ID).Sort(nodes)
-	for i := n - 1; i > 0; i-- {
-		if nodes[i].id < nodes[i-1].id {
-			t.Error("by id: not sorted")
-			printNodes(t, nodes)
+	t.Run("ByID", func(t *testing.T) {
+		ns := slices.Clone(nodes)
+		slices.SortFunc(ns, ID)
+		for i := 1; i < len(ns); i++ {
+			if ns[i].id < ns[i-1].id {
+				t.Error("by id: not sorted")
+				printNodes(t, ns)
+			}
 		}
-	}
+	})
 
-	OrderedBy(LastNodeError).Sort(nodes)
-	for i := n - 1; i > 0; i-- {
-		if nodes[i].LastErr() == nil && nodes[i-1].LastErr() != nil {
-			t.Error("by error: not sorted")
-			printNodes(t, nodes)
+	t.Run("ByLastNodeError", func(t *testing.T) {
+		ns := slices.Clone(nodes)
+		slices.SortFunc(ns, LastNodeError)
+		for i := 1; i < len(ns); i++ {
+			if ns[i].LastErr() == nil && ns[i-1].LastErr() != nil {
+				t.Error("by error: not sorted")
+				printNodes(t, ns)
+			}
 		}
-	}
+	})
+
+	t.Run("ByLastNodeErrorThenID", func(t *testing.T) {
+		ns := slices.Clone(nodes)
+		slices.SortFunc(ns, func(a, b *Node) int {
+			if c := LastNodeError(a, b); c != 0 {
+				return c
+			}
+			return ID(a, b)
+		})
+		// Expect: 42 (no err), 100 (no err), 99 (err), 101 (err).
+		wantIDs := []uint32{42, 100, 99, 101}
+		for i, n := range ns {
+			if n.id != wantIDs[i] {
+				t.Errorf("by error then id: position %d: got id %d, want %d", i, n.id, wantIDs[i])
+				printNodes(t, ns)
+			}
+		}
+	})
 }
 
 func printNodes(t *testing.T, nodes []*Node) {


### PR DESCRIPTION
This removes the bespoke sort.Interface-based MultiSorter machinery from node.go (MultiSorter, OrderedBy, lessFunc, Port) and replace it with the standard slices.SortFunc helper.

Change ID and LastNodeError from bool-returning lessFunc vars to cmp-style func(a, b *Node) int, making them directly usable as slices.SortFunc comparators without any wrapper type.

Update all four internal call sites (config.go, config_opts.go, inbound_manager.go, repl.go) to call slices.SortFunc directly.

Rewrite TestNodeSort as table-driven subtests and add a new ByLastNodeErrorThenID subtest that exercises multi-key ordering via an inline composed comparator.

Fixes #317

